### PR TITLE
Feat 17 deploy app

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,17 @@
+# This file specifies files that are *not* uploaded to Google Cloud
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+
+# Node.js dependencies:
+node_modules/

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -6,12 +6,12 @@
 # For more information, run:
 #   $ gcloud topic gcloudignore
 #
-.gcloudignore
-# If you would like to upload your .git directory, .gitignore file or files
-# from your .gitignore file, remove the corresponding line
-# below:
-.git
-.gitignore
 
-# Node.js dependencies:
-node_modules/
+# Ignore everything
+/[!.]*
+/.?*
+
+# Except the Cloud Function files we want to deploy
+!build/**
+!app.yaml
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+# Cloud Deployment
+
+Ensure `gcloud` is configured to the right project. From the root directory, run `./bin/deploy-to-gcloud.sh`. The cloud configurations can be set in `app.yaml`. 
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,14 @@
+runtime: nodejs16 # or another supported version
+
+instance_class: F1
+
+handlers:
+# Serve all static files with url ending with a file extension
+- url: /(.*\..+)$
+  static_files: build/\1
+  upload: build/(.*\..+)$
+# Catch all handler to index.html
+- url: /.*
+  static_files: build/index.html
+  upload: build/index.html
+

--- a/bin/deploy-to-gcloud.sh
+++ b/bin/deploy-to-gcloud.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+npm run build
+gcloud app deploy
+


### PR DESCRIPTION
Closes #17

Basic script to manually deploy app to gcp. In the future, we may want to consider a model of publishing the package to an artifact repository and using some other mechanism (terraform?) to deploy the app.