### PR TITLE
Feat 32 update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,10 @@
     "react-bootstrap": "^2.5.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
-    "react-scripts": "^5.0.1",
     "web-vitals": "^2.1.4"
+  },
+  "devDependencies": {
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Moves "react-scripts" dependency from "dependencies" to "devDependencies" in package.json to address the dependabot alert (about depencency vulnerability). when I run npm audit --production, it shows 0 vulnerabilities. closes #32

resources: 
https://stackoverflow.com/questions/71282206/github-dependabot-alert-inefficient-regular-expression-complexity-in-nth-check
https://bitcoden.com/answers/github-dependabot-alert-inefficient-regular-expression-complexity-in-nth-check