### PR TITLE
fixes leading/ending underscores

### DIFF
--- a/src/components/Dropdown.js
+++ b/src/components/Dropdown.js
@@ -18,13 +18,13 @@ export default function Dropdown(props) {
     <div>
       <select value={value} onChange={handleChange}>
         <option value=''> Select Schema </option>
-        <option value='data description'> Data Description Schema </option>
-        <option value='ephys rig'> Ephys Rig Schema </option>
-        <option value='ephys session'> Ephys Session Schema </option>
-        <option value='imaging acquisition'> Imaging Acquisition Schema </option>
-        <option value='imaging instrument'> Imaging Instrument Schema </option>
-        <option value='ophys rig'> Ophys Rig Schema </option>
-        <option value='ophys session'> Ophys Session Schema </option>
+        <option value='data_description'> Data Description Schema </option>
+        <option value='ephys_rig'> Ephys Rig Schema </option>
+        <option value='ephys_session'> Ephys Session Schema </option>
+        <option value='imaging_acquisition'> Imaging Acquisition Schema </option>
+        <option value='imaging_instrument'> Imaging Instrument Schema </option>
+        <option value='ophys_rig'> Ophys Rig Schema </option>
+        <option value='ophys_session'> Ophys Session Schema </option>
         <option value='procedures'> Procedures Schema </option>
         <option value='processing'> Processing Schema </option>
         <option value='subject'> Subject Schema </option>

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -27,11 +27,10 @@ export default function RenderForm (props) {
     /*
     File system access API to select save location
     */
-   const filename = JSON.stringify(schemaKey);
    const data = event.formData;
    const fileData = JSON.stringify(data, undefined, 4);
    const opts = {
-    suggestedName: `${filename}.json`,
+    suggestedName: schemaKey,
     types: [
       {
         description: "JSON file",

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -30,7 +30,7 @@ export default function RenderForm (props) {
    const data = event.formData;
    const fileData = JSON.stringify(data, undefined, 4);
    const opts = {
-    suggestedName: schemaKey,
+    suggestedName: `${schemaKey}.json`,
     types: [
       {
         description: "JSON file",

--- a/src/utilities/constants.js
+++ b/src/utilities/constants.js
@@ -10,16 +10,16 @@ import ophys_session from '../schemas/ophys_session_schema.json';
 import imaging_acquisition from '../schemas/acquisition_schema.json';
 
 const schema_map = {
-    'data description': data_description,
+    'data_description': data_description,
     'procedures': procedures,
     'processing': processing,
     'subject': subject,
-    'ephys session': ephys_session,
-    'ephys rig': ephys_rig,
-    'imaging instrument': imaging_instrument,
-    'ophys rig': ophys_rig,
-    'ophys session': ophys_session,
-    'imaging acquisition': imaging_acquisition
+    'ephys_session': ephys_session,
+    'ephys_rig': ephys_rig,
+    'imaging_instrument': imaging_instrument,
+    'ophys_rig': ophys_rig,
+    'ophys_session': ophys_session,
+    'imaging_acquisition': imaging_acquisition
 }
 
 export default schema_map; 


### PR DESCRIPTION
closes #63 
- removes the leading and ending underscores from the suggeted save filename and puts underscore in whitespace within filename (for ex: `data_description` instead of  `_data description_`)
<img width="341" alt="Screen Shot 2023-04-14 at 2 24 47 PM" src="https://user-images.githubusercontent.com/54870020/232157605-9bfd8c25-eae2-40c6-8775-d49c805cde55.png">
