### PR TITLE
Fix for latest schema render fail

### DIFF
--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -6,16 +6,17 @@ const preProcessingHelper = (obj) => {
     */ 
     Object.keys(obj).forEach(key => {
 
-      const prop = obj[key]
+      if (obj[key] !== null) {
+        const prop = obj[key]
       if (prop.const !== undefined) {
         prop.readOnly = true;
-        prop.default = prop.const
+        prop.default = prop.const;
       }
 
       if (typeof(prop) === 'object') {
-        preProcessingHelper(prop)
+        preProcessingHelper(prop);
       }
-    })
+}})
   }
 
   export const preProcessing = (schema) => {


### PR DESCRIPTION
closes #80 

- The latest versions for both subject and procedures were not rendering because preProcessingHelper was getting stuck on Species  'abbreviation' (because the value of this field is null). 
- This PR adds a check in preProcessingHelper for the value obj[key] so that it won't get stuck if something is defined as null. 