### PR TITLE
Fix 119: Fix pre-process and render issues and improve UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "react-bootstrap": "^2.8.0",
         "react-datetime": "^3.2.0",
         "react-router-dom": "^6.16.0",
+        "react-toastify": "^10.0.4",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
@@ -17909,6 +17910,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-toastify": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.4.tgz",
+      "integrity": "sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
+    "node_modules/react-toastify/node_modules/clsx": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -35090,6 +35111,21 @@
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true
+        }
+      }
+    },
+    "react-toastify": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.4.tgz",
+      "integrity": "sha512-etR3RgueY8pe88SA67wLm8rJmL1h+CLqUGHuAoNsseW35oTGJEri6eBTyaXnFKNQ80v/eO10hBYLgz036XRGgA==",
+      "requires": {
+        "clsx": "^2.1.0"
+      },
+      "dependencies": {
+        "clsx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
+          "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-bootstrap": "^2.8.0",
     "react-datetime": "^3.2.0",
     "react-router-dom": "^6.16.0",
+    "react-toastify": "^10.0.4",
     "web-vitals": "^2.1.4"
   },
   "overrides": {

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,7 +1,7 @@
 import React, {useState, useEffect} from "react";
 import RenderForm from "./RenderForm";
 import RehydrateForm from "./RehydrateForm";
-import {preProcessing} from '../utilities/schemaHandlers';
+import {preProcessSchema} from '../utilities/schemaHandlers';
 import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from "../utilities/schemaFetchers";
 import Dropdowns from "./Dropdowns";
 
@@ -79,9 +79,12 @@ export default function App(props) {
         try {
             const response = await fetch(process.env.REACT_APP_S3_URL+'/'+url);
             const schema = await response.json();
-            const processedSchema = await schema ? preProcessing(schema) : undefined;
+            const processedSchema = await schema ? preProcessSchema(schema) : undefined;
             setSchema(processedSchema);
-        } catch (error) {}
+        } catch (error) {
+            console.error(error);
+            alert(`Unable to render ${url}`);
+        }
     }
 
     return (

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -3,7 +3,7 @@ import RenderForm from "./RenderForm";
 import RehydrateForm from "./RehydrateForm";
 import {preProcessSchema} from '../utilities/schemaHandlers';
 import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from "../utilities/schemaFetchers";
-import Dropdowns from "./Dropdowns";
+import Toolbar from "./Toolbar";
 import styles from './App.module.css';
 
 export default function App(props) {
@@ -93,13 +93,13 @@ export default function App(props) {
         <div>
             <h1> AIND Metadata Entry </h1>
             <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
-            <button onClick={handleRehydrate}>Autofill Form with Existing Data</button>
-            <div className={styles.dropdownsSection}>
-                < Dropdowns 
+            <div className={styles.toolbarSection}>
+                < Toolbar 
                     ParentTypeCallback={typeCallbackFunction}
                     ParentVersionCallback={versionCallbackFunction}
                     schemaVersion={selectedSchemaVersion}
                     schemaList={schemaList}
+                    handleRehydrate={handleRehydrate}
                 />
             </div>
             <div className={styles.formSection}>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from "react";
+import { toast } from 'react-toastify';
 import RenderForm from "./RenderForm";
 import RehydrateForm from "./RehydrateForm";
 import {preProcessSchema} from '../utilities/schemaHandlers';
@@ -85,14 +86,16 @@ export default function App(props) {
             setSchema(processedSchema);
         } catch (error) {
             console.error(error);
-            alert(`Unable to render ${url}`);
+            toast.error(`Unable to render ${url}`);
         }
     }
 
     return (
         <div>
-            <h1> AIND Metadata Entry </h1>
-            <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
+            <div className={styles.titleSection}>
+                <h1> AIND Metadata Entry </h1>
+                <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
+            </div>
             <div className={styles.toolbarSection}>
                 < Toolbar 
                     ParentTypeCallback={typeCallbackFunction}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -4,6 +4,7 @@ import RehydrateForm from "./RehydrateForm";
 import {preProcessSchema} from '../utilities/schemaHandlers';
 import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from "../utilities/schemaFetchers";
 import Dropdowns from "./Dropdowns";
+import styles from './App.module.css';
 
 export default function App(props) {
     /*
@@ -13,6 +14,7 @@ export default function App(props) {
         Renders dropdown menu with options
         Gives user the option to autofill the form with previously input data
      */
+    const appVersionMsg = props.appVersion ? `App version ${props.appVersion}` : null;
     const [data, setData] = useState(null);
     const [schema, setSchema] = useState('');
     const [selectedSchemaType, setSelectedSchemaType] = useState('');
@@ -90,18 +92,19 @@ export default function App(props) {
     return (
         <div>
             <h1> AIND Metadata Entry </h1>
-            <div>User-interface for metadata ingest and validation. Use on Chrome.</div>
+            <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
             <button onClick={handleRehydrate}>Autofill Form with Existing Data</button>
-            <div>
+            <div className={styles.dropdownsSection}>
                 < Dropdowns 
                     ParentTypeCallback={typeCallbackFunction}
                     ParentVersionCallback={versionCallbackFunction}
                     schemaVersion={selectedSchemaVersion}
-                    schemaList={schemaList}/>
+                    schemaList={schemaList}
+                />
             </div>
-            <div>
+            <div className={styles.formSection}>
                 <RenderForm schema={schema} data={data} selectedSchemaType={selectedSchemaType}/> 
-           </div>
+            </div>
         </div>
     );
 };

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -1,19 +1,19 @@
 body {
     padding: 40px;
-    text-align: center;
 
-    h1 {
+    .titleSection {
         text-align: center;
-        color: navy;
+
+        h1 {
+            color: navy;
+        }
     }
 
     .toolbarSection {
-        text-align: left;
         margin-top: 30px;
     }
 
     .formSection {
-        text-align: left;
         padding: 15px;
         border: 1px dashed grey;
     }

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -1,0 +1,20 @@
+body {
+    padding: 40px;
+    text-align: center;
+
+    h1 {
+        text-align: center;
+        color: navy;
+    }
+
+    .dropdownsSection {
+        text-align: left;
+        margin-top: 30px;
+    }
+
+    .formSection {
+        text-align: left;
+        padding: 15px;
+        border: 1px dashed grey;
+    }
+}

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -7,7 +7,7 @@ body {
         color: navy;
     }
 
-    .dropdownsSection {
+    .toolbarSection {
         text-align: left;
         margin-top: 30px;
     }

--- a/src/components/RehydrateForm.js
+++ b/src/components/RehydrateForm.js
@@ -6,7 +6,7 @@ export default async function RehydrateForm (props) {
         Uses file system access API to access local files
         Returns pre-existing data (JSON object)
     */
-    alert("Select a JSON file that matches selected schema from local file system.")
+    alert("Select a JSON file from local file system that matches selected schema.")
     let fileHandle;
     let formData = null;
 

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,11 +1,13 @@
 import React, { useState } from 'react';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import {compareVersions} from 'compare-versions';
+import styles from './Toolbar.module.css';
 
-export default function Dropdowns (props) {
+export default function Toolbar (props) {
     /**
-     * Application to render a dropdown menu for schema-selection.
+     * Component to render a dropdown menu for schema-selection.
      * Based on selected schema, renders a dropdown menu for version-selection. 
+     * Gives user the option to autofill the form with previously input data
      */
   const [selectedSchemaType, setSelectedSchemaType] = useState('');
   const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('');
@@ -41,36 +43,42 @@ export default function Dropdowns (props) {
     <div>
       <select
         id="schema-type-select"
+        className={["btn", "btn-default", styles.dropdown].join(" ")}
         title='Select a schema'
         value={selectedSchemaType}
         onChange={handleTypeChange}
       >
-        <option value="">Select a Schema</option>
+        <option value="">Select schema</option>
         {schemaTypes.map((schemaType) => (
           <option key={schemaType} value={schemaType}>
             {schemaType}
           </option>
         ))}
       </select>
-      <br />
-      <div></div>
-      {selectedSchemaType && (
-        <>
-          <select
-            id="schema-version-select"
-            title='Select a version'
-            value={selectedSchemaVersion}
-            onChange={handleVersionChange}
-          >
-            <option value="">Select Version</option>
-            {versions.map((version) => (
-              <option key={version} value={version}>
-                {version}
-              </option>
-            ))}
-          </select>
-        </>
-      )}
+      <select
+        id="schema-version-select"
+        className={["btn", "btn-default", styles.dropdown].join(" ")}
+        title='Select a version'
+        value={selectedSchemaVersion}
+        onChange={handleVersionChange}
+        disabled={!selectedSchemaType}
+      >
+        <option value="">Select version</option>
+        {versions.map((version) => (
+          <option key={version} value={version}>
+            {version}
+          </option>
+        ))}
+      </select>
+      <button
+        title="Autofill with existing data"
+        type="button"
+        className={["btn", "btn-default", styles.btnRight].join(" ")}
+        onClick={props.handleRehydrate}
+        disabled={!selectedSchemaType}
+      >
+        Autofill with existing data
+      </button>
     </div>
   );
 };

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -1,0 +1,11 @@
+.dropdown {
+    font-size: medium;
+    color: navy;
+    margin-right: 5px;
+    text-align: left
+}
+
+.btnRight {
+    float: right;
+    color: navy;
+}

--- a/src/components/Toolbar.test.js
+++ b/src/components/Toolbar.test.js
@@ -1,30 +1,35 @@
 import { render, screen, fireEvent } from "@testing-library/react";
-import Dropdowns from "./Dropdowns";
+import Toolbar from "./Toolbar";
 import sampleSchemaList from '../testing/sample-schema-list.json';
 import sampleSortedVersionListInstrument from '../testing/sample-sorted-version-list-instrument.json';
 
 const nullCallback = () => { }
 
-describe("Dropdowns component", () => {
-  it("renders only schema type selection dropdown on default", () => {
-    render(<Dropdowns
+describe("Toolbar component", () => {
+  it("renders appropriate inputs on default", () => {
+    render(<Toolbar
       schemaList={sampleSchemaList}
     />);
     expect(screen.getByTitle('Select a schema')).toBeInTheDocument();
-    expect(screen.queryByTitle('Select a version')).toBeNull();
+    expect(screen.getByTitle('Select a version')).toBeInTheDocument();
+    expect(screen.getByTitle('Autofill with existing data')).toBeInTheDocument();
+    expect(screen.getByTitle('Select a schema')).toBeEnabled();
+    expect(screen.getByTitle('Select a version')).toBeDisabled();
+    expect(screen.getByTitle('Autofill with existing data')).toBeDisabled();
   })
 
-  it("renders schema version selection dropdown when a schema type is chosen", () => {
-    render(<Dropdowns
+  it("enables version selection dropdown and autofill/ upload button when a schema type is chosen", () => {
+    render(<Toolbar
       ParentTypeCallback={nullCallback}
       schemaList={sampleSchemaList}
     />);
     fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } });
-    expect(screen.getByTitle('Select a version')).toBeInTheDocument();
+    expect(screen.getByTitle('Select a version')).toBeEnabled();
+    expect(screen.getByTitle('Autofill with existing data')).toBeEnabled();
   })
 
   it("has schema versions sorted by latest-first semantic version", () => {
-    render(<Dropdowns
+    render(<Toolbar
       ParentTypeCallback={nullCallback}
       schemaList={sampleSchemaList}
     />);

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,6 @@
 body {
   max-width: 80%;
+  margin: auto;
 }
 
 div.form-group.field.field-integer {
@@ -34,9 +35,4 @@ p.col-xs-offset-9 {
 
 div {
   margin: 5px;
-}
-  
-h1 {
-  color: navy;
-  margin: 10px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,7 @@
 body {
   max-width: 80%;
   margin: auto;
+  --toastify-toast-width: 400px;
 }
 
 div.form-group.field.field-integer {

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactDOM from 'react-dom/client'; 
 import App from './components/App';
 import reportWebVitals from './reportWebVitals';
+import { ToastContainer } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 import './index.css';
 
 const appVersion = require('../package.json').version;
@@ -11,7 +13,10 @@ console.log('schemas to filter: ', process.env.REACT_APP_FILTER_SCHEMAS)
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-    <App appVersion={appVersion} />
+    <div>
+        <App appVersion={appVersion} />
+        <ToastContainer autoClose={8000} />
+    </div>
 );
 
 reportWebVitals();

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ console.log('schemas to filter: ', process.env.REACT_APP_FILTER_SCHEMAS)
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-    <App />
+    <App appVersion={appVersion} />
 );
 
 reportWebVitals();

--- a/src/testing/sample-sorted-version-list-instrument.json
+++ b/src/testing/sample-sorted-version-list-instrument.json
@@ -1,5 +1,5 @@
 [
-    "Select Version",
+    "Select version",
     "0.10.1",
     "0.10.0",
     "0.9.5",

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -26,7 +26,7 @@ const testSchema2 = ({
         },
         parameters: {
             title: "parameters",
-            type: "strobjecting",
+            type: "object",
             default: {}
         }
     },
@@ -45,7 +45,14 @@ const testSchema3 = ({
         },
         email: {
             title: "Email Address",
-            type: "string"
+            anyOf: [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "null"
+                }
+            ]
         }, 
         resume: {
             title: "Resume",
@@ -114,6 +121,12 @@ test("Checks preProcessSchema modifies dictionary additional properties", () => 
     expect(processedSchema2.properties.parameters.additionalProperties).toStrictEqual({"type": "string"})
 })
 
+test("Checks preProcessSchema add default title to `anyOf` options if needed", () => {
+    const processedSchema3 = preProcessSchema(testSchema3);
+    expect(processedSchema3.properties.email.anyOf).toStrictEqual([{ "title": "string", "type": "string" }, { "title": "null", "type": "null" }])
+})
+
+
 test("Checks preProcessSchema recurses through nested schema as expected", () => {
     const processedSchema3 = preProcessSchema(testSchema3);
     expect(processedSchema3.properties.resume.properties.education.readOnly).toBe(true);
@@ -121,7 +134,7 @@ test("Checks preProcessSchema recurses through nested schema as expected", () =>
     expect(processedSchema3.definitions.PastExperience.key_points.additionalProperties).toStrictEqual({"type": "string"})
 })
 
-test("Checks preProcessSchema does not modify sample schema", () => {
+test("Checks preProcessSchema does not modify simple sample schema", () => {
     const processedSchema = preProcessSchema(testSchema4);
     expect(processedSchema).toEqual(testSchema4);
 })

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -1,4 +1,4 @@
-import {preProcessing} from './schemaHandlers';
+import {preProcessSchema} from './schemaHandlers';
 
 const testSchema1 = ({
     type: "object",
@@ -103,25 +103,25 @@ const testSchema4 = ({
     ]
 });
 
-test("Checks preProcessing modifies const schema", () => {
-    const processedSchema1 = preProcessing(testSchema1);
+test("Checks preProcessSchema modifies const schema", () => {
+    const processedSchema1 = preProcessSchema(testSchema1);
     expect(processedSchema1.properties.describedBy.default).toBe(testSchema1.properties.describedBy.const);
     expect(processedSchema1.properties.describedBy.readOnly).toBe(true);
 })
 
-test("Checks preProcessing modifies dictionary additional properties", () => {
-    const processedSchema2 = preProcessing(testSchema2);
+test("Checks preProcessSchema modifies dictionary additional properties", () => {
+    const processedSchema2 = preProcessSchema(testSchema2);
     expect(processedSchema2.properties.parameters.additionalProperties).toStrictEqual({"type": "string"})
 })
 
-test("Checks preProcessing recurses through nested schema as expected", () => {
-    const processedSchema3 = preProcessing(testSchema3);
+test("Checks preProcessSchema recurses through nested schema as expected", () => {
+    const processedSchema3 = preProcessSchema(testSchema3);
     expect(processedSchema3.properties.resume.properties.education.readOnly).toBe(true);
     expect(processedSchema3.properties.resume.properties.education.default).toBe(testSchema3.properties.resume.properties.education.const);
     expect(processedSchema3.definitions.PastExperience.key_points.additionalProperties).toStrictEqual({"type": "string"})
 })
 
-test("Checks preProcessing does not modify sample schema", () => {
-    const processedSchema = preProcessing(testSchema4);
+test("Checks preProcessSchema does not modify sample schema", () => {
+    const processedSchema = preProcessSchema(testSchema4);
     expect(processedSchema).toEqual(testSchema4);
 })

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -16,7 +16,7 @@ const preProcessHelper = (obj) => {
           }
 
           // if default is {}, expected value is a dictionary of strings 
-          if (typeof(prop.default) === 'object' && Object.keys(prop.default).length === 0) {
+          if (prop.default && typeof(prop.default) === 'object' && Object.keys(prop.default).length === 0) {
             prop.additionalProperties={"type": "string"}
           }
     
@@ -26,7 +26,7 @@ const preProcessHelper = (obj) => {
           }
         }
       });
-    };
+};
 
 export const preProcessSchema = (schema) => {
   /*

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,3 +1,5 @@
+import { toast } from 'react-toastify';
+
 const preProcessHelper = (obj) => {
   /* 
   Recursively iterates through schema for rendering purposes
@@ -53,7 +55,7 @@ export const preProcessSchema = (schema) => {
     const msg = `Error processing ${schema?.title} ${schema.properties?.schema_version?.const}`
     console.error(msg, schema)
     console.error(error)
-    alert(`${msg}. Rendering raw schema instead.`)
+    toast.warn(`${msg}. Rendered raw schema instead.`)
     return schema
   }
   return copiedSchema;

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,31 +1,43 @@
 const preProcessHelper = (obj) => {
-    /* 
-    Recursively iterates through schema for rendering purposes
-      Makes const fields non-fillable
-      Renders dictionaries
-      Hack around a bug in rjsf library.
-    */ 
-      Object.keys(obj).forEach(key => {
-        if (obj[key] !== null) {
-          const prop = obj[key];
+  /* 
+  Recursively iterates through schema for rendering purposes
+    Makes const fields non-fillable
+    Renders dictionaries
+    Displays type selection dropdown with better default text
+  */
+  Object.keys(obj).forEach(key => {
+    if (obj[key] !== null) {
+      const prop = obj[key];
 
-          // grays out const fields (readOnly) and autofills the field with the const value (default)
-          if (prop.const !== undefined) {
-            prop.readOnly = true;
-            prop.default = prop.const;
-          }
+      // grays out const fields (readOnly) and autofills the field with the const value (default)
+      if (prop.const !== undefined) {
+        prop.readOnly = true;
+        prop.default = prop.const;
+      }
 
-          // if default is {}, expected value is a dictionary of strings 
-          if (prop.default && typeof(prop.default) === 'object' && Object.keys(prop.default).length === 0) {
-            prop.additionalProperties={"type": "string"}
+      // if default is {}, expected value is a dictionary of strings 
+      if (prop.default && typeof (prop.default) === 'object' && Object.keys(prop.default).length === 0) {
+        prop.additionalProperties = { "type": "string" }
+      }
+
+      // add default titles to dropdown of allowed types/ subschemas
+      if (prop.anyOf) {
+        Object.values(prop.anyOf).forEach(option => {
+          // if the allowed type/ subschema is not a ref nor has a title,
+          // it defaults to <parentProp.title> option 1, <prop.title> option 2, ...
+          // we can convert to display the type name instead
+          if (!option.$ref && option.type && !option.title) {
+            option.title = option.type
           }
-    
-          // recursion
-          if (typeof(prop) === 'object') {
-            preProcessHelper(prop);
-          }
-        }
-      });
+        })
+      }
+
+      // recursion
+      if (typeof (prop) === 'object') {
+        preProcessHelper(prop);
+      }
+    }
+  });
 };
 
 export const preProcessSchema = (schema) => {

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,4 +1,4 @@
-const preProcessingHelper = (obj) => {
+const preProcessHelper = (obj) => {
     /* 
     Recursively iterates through schema for rendering purposes
       Makes const fields non-fillable
@@ -22,19 +22,27 @@ const preProcessingHelper = (obj) => {
     
           // recursion
           if (typeof(prop) === 'object') {
-            preProcessingHelper(prop);
+            preProcessHelper(prop);
           }
         }
       });
     };
 
-  export const preProcessing = (schema) => {
-    /*
-    PreProcessing for schema validation
-      Uses helper function to make const fields non-fillable
-    */
-   let copiedSchema = JSON.parse(JSON.stringify(schema))
-    preProcessingHelper(copiedSchema)
-    return copiedSchema;
+export const preProcessSchema = (schema) => {
+  /*
+  PreProcessing for schema validation
+    Uses helper function to make const fields non-fillable
+    Returns processedSchema if successful, otherwise returns raw original schema
+  */
+  let copiedSchema = JSON.parse(JSON.stringify(schema))
+  try {
+    preProcessHelper(copiedSchema)
+  } catch (error) {
+    const msg = `Error processing ${schema?.title} ${schema.properties?.schema_version?.const}`
+    console.error(msg, schema)
+    console.error(error)
+    alert(`${msg}. Rendering raw schema instead.`)
+    return schema
   }
-  
+  return copiedSchema;
+}


### PR DESCRIPTION
closes #119 

**Fix form rendering issues:**
- Fix form render issue affecting all newer schemas for pydanticv2
- Display type options in dropdown of allowed subschemas, rather than `<field.title> option 1, <field.title> option 2, ...`  
- Render Optional/ Nullable fields from schema as null on default
- Add error handling for `preProcessSchema()` and `fetchAndSetSchema()`
   
**UX and Styling:**
- Refactor `Dropdowns` component to new `Toolbar` component
    - Move Autofill/ upload button to `Toolbar` component
    - Disable versions dropdown and autofill button unless a schema is selected
- Add `react-toastify` package for notifications to user
- Add styling for App and Toolbar components and edit display texts

Added new unit tests for `schemaHandlers.js` and `Toolbar.js`

---
![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/1232bc9f-8789-4304-9edd-3ca49e0aca8c)

---
![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/bbf916b4-881e-4408-99c6-84de0dc21c4a)

---
![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/aaba486e-e73d-4727-aab3-4e95d5c53eb8)


