### PR TITLE
Fix 124: Display schema version selection on default

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -100,7 +100,7 @@ export default function App(props) {
                 < Toolbar 
                     ParentTypeCallback={typeCallbackFunction}
                     ParentVersionCallback={versionCallbackFunction}
-                    schemaVersion={selectedSchemaVersion}
+                    selectedSchemaVersion={selectedSchemaVersion}
                     schemaList={schemaList}
                     handleRehydrate={handleRehydrate}
                 />

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -10,7 +10,6 @@ export default function Toolbar (props) {
      * Gives user the option to autofill the form with previously input data
      */
   const [selectedSchemaType, setSelectedSchemaType] = useState('');
-  const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('');
   
   const schemaList = props.schemaList
 
@@ -36,7 +35,6 @@ export default function Toolbar (props) {
 
   const handleVersionChange = (event) => {
     props.ParentVersionCallback(event.target.value);
-    setSelectedSchemaVersion(event.target.value);
   };
 
   return (
@@ -59,7 +57,7 @@ export default function Toolbar (props) {
         id="schema-version-select"
         className={["btn", "btn-default", styles.dropdown].join(" ")}
         title='Select a version'
-        value={selectedSchemaVersion}
+        value={props.selectedSchemaVersion}
         onChange={handleVersionChange}
         disabled={!selectedSchemaType}
       >


### PR DESCRIPTION
closes #124:
- display default schema version after selecting a schema, by ensuring version changes from parent `App` component are passed as props to `Toolbar` component

![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/d16d2b8e-d380-460c-8e71-e3308fab044b)
