### PR TITLE
Feat 27: Add linter and unit test frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
 ### `npm run test`, `npm run test:coverage`
-This project uses [Jest](https://jestjs.io) as its Node-based test runner. [react-testing-library](https://testing-library.com/docs/react-testing-library/intro) is used to test components in isolation.
-- Use `npm run test` to run all tests
+This project uses [Jest](https://jestjs.io) as its Node-based test runner. [React Testing Library](https://testing-library.com/docs/react-testing-library/intro) is used to test components in isolation.
+- Use `npm run test` to run all tests in watch mode
 - Use `npm run test:coverage` to run all tests and get coverage report
-See [create-react-app running tests](https://create-react-app.dev/docs/running-tests) for more information.
+
+See [Create React App - Running Tests](https://create-react-app.dev/docs/running-tests) for more information.
 
 ### `npm run lint`, `npm run lint:fix`
-
 This project uses [ESLint](https://eslint.org/docs/latest/use/core-concepts) for React, with [JS Standard Code Style](https://standardjs.com/rules).
 - Use `npm run lint` to run the linter
 - Use `npm run lint:fix` to auto-fix issues

--- a/README.md
+++ b/README.md
@@ -28,10 +28,11 @@ Open [http://localhost:3000](http://localhost:3000) to view it in your browser. 
 The page will reload when you make changes.\
 You may also see any lint errors in the console.
 
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
+### `npm run test`, `npm run test:coverage`
+This project uses [Jest](https://jestjs.io) as its Node-based test runner. [react-testing-library](https://testing-library.com/docs/react-testing-library/intro) is used to test components in isolation.
+- Use `npm run test` to run all tests
+- Use `npm run test:coverage` to run all tests and get coverage report
+See [create-react-app running tests](https://create-react-app.dev/docs/running-tests) for more information.
 
 ### `npm run lint`, `npm run lint:fix`
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,12 @@ You may also see any lint errors in the console.
 Launches the test runner in the interactive watch mode.\
 See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
 
+### `npm run lint`, `npm run lint:fix`
+
+This project uses [ESLint](https://eslint.org/docs/latest/use/core-concepts) for React, with [JS Standard Code Style](https://standardjs.com/rules).
+- Use `npm run lint` to run the linter
+- Use `npm run lint:fix` to auto-fix issues
+
 ### `npm run build`
 
 Builds the app for production to the `build` folder.\

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,9 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "eslint": "^8.56.0",
+        "eslint-config-standard": "^17.1.0",
+        "eslint-plugin-react": "^7.33.2",
         "react-scripts": "^5.0.1"
       },
       "engines": {
@@ -2658,9 +2661,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -2697,9 +2700,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.22.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-      "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -2742,9 +2745,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
-      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2757,13 +2760,13 @@
       "peer": true
     },
     "node_modules/@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "dependencies": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       },
       "engines": {
@@ -2784,9 +2787,9 @@
       }
     },
     "node_modules/@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -5509,6 +5512,12 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -6970,6 +6979,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "semver": "^7.0.0"
+      }
+    },
+    "node_modules/builtins/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/builtins/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/bytes": {
@@ -8917,18 +8965,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
-      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -8970,6 +9019,19 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+      "integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -8996,6 +9058,35 @@
       },
       "peerDependencies": {
         "eslint": "^8.0.0"
+      }
+    },
+    "node_modules/eslint-config-standard": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.1",
+        "eslint-plugin-import": "^2.25.2",
+        "eslint-plugin-n": "^15.0.0 || ^16.0.0 ",
+        "eslint-plugin-promise": "^6.0.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -9061,6 +9152,27 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+      "integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0",
+        "eslint-compat-utils": "^0.1.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ota-meshi"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
     "node_modules/eslint-plugin-flowtype": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
@@ -9080,28 +9192,28 @@
       }
     },
     "node_modules/eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "engines": {
         "node": ">=4"
@@ -9201,6 +9313,124 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
+      "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.5.0",
+        "get-tsconfig": "^4.7.0",
+        "globals": "^13.24.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mysticatea"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/resolve": {
+      "version": "1.22.8",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "is-core-module": "^2.13.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-react": {
@@ -10289,9 +10519,12 @@
       }
     },
     "node_modules/function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/function.prototype.name": {
       "version": "1.1.6",
@@ -10431,6 +10664,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/getpass": {
@@ -10788,6 +11034,17 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "peer": true
+    },
+    "node_modules/hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/he": {
       "version": "1.2.0",
@@ -11412,6 +11669,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "builtin-modules": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -11424,11 +11697,11 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -18365,6 +18638,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -20372,9 +20655,9 @@
       "dev": true
     },
     "node_modules/tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "dependencies": {
         "@types/json5": "^0.0.29",
@@ -23676,9 +23959,9 @@
       "dev": true
     },
     "@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -23705,9 +23988,9 @@
           }
         },
         "globals": {
-          "version": "13.22.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.22.0.tgz",
-          "integrity": "sha512-H1Ddc/PbZHTDVJSnj8kWptIRSD6AM3pK+mKytuIVF4uoBV7rshFlhhvA58ceJ5wp3Er58w6zj7bykMpYXt3ETw==",
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -23734,9 +24017,9 @@
       }
     },
     "@eslint/js": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.50.0.tgz",
-      "integrity": "sha512-NCC3zz2+nvYd+Ckfh87rA47zfu2QsQpvc6k1yzTk+b9KzRj0wkGa8LSoGOXN6Zv4lRf/EIoZ80biDh9HOI+RNQ==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.56.0.tgz",
+      "integrity": "sha512-gMsVel9D7f2HLkBma9VbtzZRehRogVRfbr++f06nL2vnCGCNlzOD+/MUov/F4p8myyAHspEhVobgjpX64q5m6A==",
       "dev": true
     },
     "@gar/promisify": {
@@ -23746,13 +24029,13 @@
       "peer": true
     },
     "@humanwhocodes/config-array": {
-      "version": "0.11.11",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-      "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+      "version": "0.11.14",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
+      "integrity": "sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==",
       "dev": true,
       "requires": {
-        "@humanwhocodes/object-schema": "^1.2.1",
-        "debug": "^4.1.1",
+        "@humanwhocodes/object-schema": "^2.0.2",
+        "debug": "^4.3.1",
         "minimatch": "^3.0.5"
       }
     },
@@ -23763,9 +24046,9 @@
       "dev": true
     },
     "@humanwhocodes/object-schema": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-      "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz",
+      "integrity": "sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==",
       "dev": true
     },
     "@istanbuljs/load-nyc-config": {
@@ -25834,6 +26117,12 @@
         "eslint-visitor-keys": "^3.3.0"
       }
     },
+    "@ungap/structured-clone": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+      "dev": true
+    },
     "@webassemblyjs/ast": {
       "version": "1.11.6",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.11.6.tgz",
@@ -26969,6 +27258,38 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
       "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
       "dev": true
+    },
+    "builtins": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
+      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "semver": "^7.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "bytes": {
       "version": "3.0.0",
@@ -28457,18 +28778,19 @@
       }
     },
     "eslint": {
-      "version": "8.50.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.50.0.tgz",
-      "integrity": "sha512-FOnOGSuFuFLv/Sa+FDVRZl4GGVAAFFi8LecRsI5a1tMO5HIE8nCm4ivAlzt4dT3ol/PaaGC0rJEEXQmHJBGoOg==",
+      "version": "8.56.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.56.0.tgz",
+      "integrity": "sha512-Go19xM6T9puCOWntie1/P997aXxFsOi37JIHRWI514Hc6ZnaHGKY9xFhrU65RT6CcBEzZoGG1e6Nq+DT04ZtZQ==",
       "dev": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.50.0",
-        "@humanwhocodes/config-array": "^0.11.11",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.56.0",
+        "@humanwhocodes/config-array": "^0.11.13",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.2",
@@ -28536,6 +28858,14 @@
         }
       }
     },
+    "eslint-compat-utils": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.1.2.tgz",
+      "integrity": "sha512-Jia4JDldWnFNIru1Ehx1H5s9/yxiRHY/TimCuUc0jNexew3cF1gI6CYZil1ociakfWO3rRqFjl1mskBblB3RYg==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.1.tgz",
@@ -28557,6 +28887,13 @@
         "eslint-plugin-react-hooks": "^4.3.0",
         "eslint-plugin-testing-library": "^5.0.1"
       }
+    },
+    "eslint-config-standard": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
+      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-import-resolver-node": {
       "version": "0.3.9",
@@ -28611,6 +28948,18 @@
         }
       }
     },
+    "eslint-plugin-es-x": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.5.0.tgz",
+      "integrity": "sha512-ODswlDSO0HJDzXU0XvgZ3lF3lS3XAZEossh15Q2UHjwrJggWeBoKqqEsLTZLXl+dh5eOAozG0zRcYtuE35oTuQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.6.0",
+        "eslint-compat-utils": "^0.1.2"
+      }
+    },
     "eslint-plugin-flowtype": {
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/eslint-plugin-flowtype/-/eslint-plugin-flowtype-8.0.3.tgz",
@@ -28622,28 +28971,28 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.28.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.28.1.tgz",
-      "integrity": "sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==",
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.1.tgz",
+      "integrity": "sha512-BbPC0cuExzhiMo4Ff1BTVwHpjjv28C5R+btTOGaCRC7UEz801up0JadwkeSk5Ued6TG34uaczuVuH6qyy5YUxw==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.1.6",
-        "array.prototype.findlastindex": "^1.2.2",
-        "array.prototype.flat": "^1.3.1",
-        "array.prototype.flatmap": "^1.3.1",
+        "array-includes": "^3.1.7",
+        "array.prototype.findlastindex": "^1.2.3",
+        "array.prototype.flat": "^1.3.2",
+        "array.prototype.flatmap": "^1.3.2",
         "debug": "^3.2.7",
         "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.7",
+        "eslint-import-resolver-node": "^0.3.9",
         "eslint-module-utils": "^2.8.0",
-        "has": "^1.0.3",
-        "is-core-module": "^2.13.0",
+        "hasown": "^2.0.0",
+        "is-core-module": "^2.13.1",
         "is-glob": "^4.0.3",
         "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.6",
-        "object.groupby": "^1.0.0",
-        "object.values": "^1.1.6",
+        "object.fromentries": "^2.0.7",
+        "object.groupby": "^1.0.1",
+        "object.values": "^1.1.7",
         "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
+        "tsconfig-paths": "^3.15.0"
       },
       "dependencies": {
         "debug": {
@@ -28712,6 +29061,85 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-n": {
+      "version": "16.6.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-16.6.2.tgz",
+      "integrity": "sha512-6TyDmZ1HXoFQXnhCTUjVFULReoBPOAjpuiKELMkeP40yffI/1ZRO+d9ug/VC6fqISo2WkuIBk3cvuRPALaWlOQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "builtins": "^5.0.1",
+        "eslint-plugin-es-x": "^7.5.0",
+        "get-tsconfig": "^4.7.0",
+        "globals": "^13.24.0",
+        "ignore": "^5.2.4",
+        "is-builtin-module": "^3.2.1",
+        "is-core-module": "^2.12.1",
+        "minimatch": "^3.1.2",
+        "resolve": "^1.22.2",
+        "semver": "^7.5.3"
+      },
+      "dependencies": {
+        "globals": {
+          "version": "13.24.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+          "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "type-fest": "^0.20.2"
+          }
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "resolve": {
+          "version": "1.22.8",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+          "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "is-core-module": "^2.13.0",
+            "path-parse": "^1.0.7",
+            "supports-preserve-symlinks-flag": "^1.0.0"
+          }
+        },
+        "semver": {
+          "version": "7.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+          "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "type-fest": {
+          "version": "0.20.2",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+          "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+          "dev": true,
+          "peer": true
+        }
+      }
+    },
+    "eslint-plugin-promise": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
+      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
+      "dev": true,
+      "peer": true,
+      "requires": {}
     },
     "eslint-plugin-react": {
       "version": "7.33.2",
@@ -29480,9 +29908,9 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
     },
     "function.prototype.name": {
       "version": "1.1.6",
@@ -29580,6 +30008,16 @@
       "requires": {
         "call-bind": "^1.0.2",
         "get-intrinsic": "^1.1.1"
+      }
+    },
+    "get-tsconfig": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.2.tgz",
+      "integrity": "sha512-wuMsz4leaj5hbGgg4IvDU0bqJagpftG5l5cXIAvo8uZrqn0NJqwtfupTN00VnkQJPcIRrxYrm1Ue24btpCha2A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "resolve-pkg-maps": "^1.0.0"
       }
     },
     "getpass": {
@@ -29845,6 +30283,14 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "peer": true
+    },
+    "hasown": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "requires": {
+        "function-bind": "^1.1.2"
+      }
     },
     "he": {
       "version": "1.2.0",
@@ -30320,17 +30766,27 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-builtin-module": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-3.2.1.tgz",
+      "integrity": "sha512-BSLE3HnV2syZ0FK0iMA/yUGplUeMmNz4AW5fnTunbCIqZi4vG3WjJT9FHMy5D69xmAYBHXQhJdALdpwVxV501A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "builtin-modules": "^3.3.0"
+      }
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
       "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA=="
     },
     "is-core-module": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-      "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "requires": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "is-date-object": {
@@ -35477,6 +35933,13 @@
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
       "dev": true
     },
+    "resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "peer": true
+    },
     "resolve-url-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-5.0.0.tgz",
@@ -37026,9 +37489,9 @@
       "dev": true
     },
     "tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
       "dev": true,
       "requires": {
         "@types/json5": "^0.0.29",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
-    "test": "react-scripts test",
+    "test": "react-scripts test .",
+    "test:coverage": "react-scripts test . --coverage",
     "lint": "eslint src/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix",
     "eject": "react-scripts eject"

--- a/package.json
+++ b/package.json
@@ -33,18 +33,26 @@
     "node": ">=16.0.0 <17.0.0"
   },
   "devDependencies": {
+    "eslint": "^8.56.0",
+    "eslint-config-standard": "^17.1.0",
+    "eslint-plugin-react": "^7.33.2",
     "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
+    "lint": "eslint src/**/*.js",
+    "lint:fix": "eslint src/**/*.js --fix",
     "eject": "react-scripts eject"
   },
   "eslintConfig": {
     "extends": [
       "react-app",
-      "react-app/jest"
+      "react-app/jest",
+      "eslint:recommended",
+      "plugin:react/recommended",
+      "standard"
     ]
   },
   "browserslist": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,16 @@
     "lint:fix": "eslint src/**/*.js --fix",
     "eject": "react-scripts eject"
   },
+  "jest": {
+    "coverageThreshold": {
+      "global": {
+        "branches": 29,
+        "functions": 32,
+        "lines": 22,
+        "statements": 22
+      }
+    }
+  },
   "eslintConfig": {
     "extends": [
       "react-app",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test .",
-    "test:coverage": "react-scripts test . --coverage",
+    "test:coverage": "react-scripts test . --coverage --watchAll=false",
     "lint": "eslint src/**/*.js",
     "lint:fix": "eslint src/**/*.js --fix",
     "eject": "react-scripts eject"
@@ -63,6 +63,7 @@
       "react-app/jest",
       "eslint:recommended",
       "plugin:react/recommended",
+      "plugin:import/errors",
       "standard"
     ]
   },

--- a/package.json
+++ b/package.json
@@ -50,10 +50,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
+        "statements": 22,
         "branches": 29,
         "functions": 32,
-        "lines": 22,
-        "statements": 22
+        "lines": 23
       }
     }
   },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
 import { toast } from 'react-toastify'
 import RenderForm from './RenderForm'
 import RehydrateForm from './RehydrateForm'
@@ -7,7 +8,7 @@ import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from '../utiliti
 import Toolbar from './Toolbar'
 import styles from './App.module.css'
 
-export default function App (props) {
+function App (props) {
   /*
     Application to display a dropdown menu of schemas.
         Fetches schema objects from s3
@@ -15,9 +16,10 @@ export default function App (props) {
         Renders dropdown menu with options
         Gives user the option to autofill the form with previously input data
      */
-  const appVersionMsg = props.appVersion ? `App version ${props.appVersion}` : null
+  const { appVersion } = props
+  const appVersionMsg = appVersion ? `App version ${appVersion}` : null
   const [data, setData] = useState(null)
-  const [schema, setSchema] = useState('')
+  const [schema, setSchema] = useState(null)
   const [selectedSchemaType, setSelectedSchemaType] = useState('')
   const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('')
 
@@ -91,23 +93,29 @@ export default function App (props) {
   }
 
   return (
-        <div>
-            <div className={styles.titleSection}>
-                <h1> AIND Metadata Entry </h1>
-                <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
-            </div>
-            <div className={styles.toolbarSection}>
-                < Toolbar
-                    ParentTypeCallback={typeCallbackFunction}
-                    ParentVersionCallback={versionCallbackFunction}
-                    selectedSchemaVersion={selectedSchemaVersion}
-                    schemaList={schemaList}
-                    handleRehydrate={handleRehydrate}
-                />
-            </div>
-            <div className={styles.formSection}>
-                <RenderForm schema={schema} data={data} selectedSchemaType={selectedSchemaType}/>
-            </div>
-        </div>
+    <div>
+      <div className={styles.titleSection}>
+        <h1> AIND Metadata Entry </h1>
+        <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
+      </div>
+      <div className={styles.toolbarSection}>
+        < Toolbar
+          ParentTypeCallback={typeCallbackFunction}
+          ParentVersionCallback={versionCallbackFunction}
+          selectedSchemaVersion={selectedSchemaVersion}
+          schemaList={schemaList}
+          handleRehydrate={handleRehydrate}
+        />
+      </div>
+      <div className={styles.formSection}>
+        <RenderForm schemaType={selectedSchemaType} schema={schema} formData={data} />
+      </div>
+    </div>
   )
 }
+
+App.propTypes = {
+  appVersion: PropTypes.string.isRequired
+}
+
+export default App

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,103 +1,103 @@
-import React, {useState, useEffect} from "react";
-import { toast } from 'react-toastify';
-import RenderForm from "./RenderForm";
-import RehydrateForm from "./RehydrateForm";
-import {preProcessSchema} from '../utilities/schemaHandlers';
-import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from "../utilities/schemaFetchers";
-import Toolbar from "./Toolbar";
-import styles from './App.module.css';
+import React, { useState, useEffect } from 'react'
+import { toast } from 'react-toastify'
+import RenderForm from './RenderForm'
+import RehydrateForm from './RehydrateForm'
+import { preProcessSchema } from '../utilities/schemaHandlers'
+import { fetchSchemasfromS3, findLatestSchemas, filterSchemas } from '../utilities/schemaFetchers'
+import Toolbar from './Toolbar'
+import styles from './App.module.css'
 
-export default function App(props) {
-    /*
+export default function App (props) {
+  /*
     Application to display a dropdown menu of schemas.
         Fetches schema objects from s3
         Creates schema objects from filepaths
         Renders dropdown menu with options
         Gives user the option to autofill the form with previously input data
      */
-    const appVersionMsg = props.appVersion ? `App version ${props.appVersion}` : null;
-    const [data, setData] = useState(null);
-    const [schema, setSchema] = useState('');
-    const [selectedSchemaType, setSelectedSchemaType] = useState('');
-    const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('');
+  const appVersionMsg = props.appVersion ? `App version ${props.appVersion}` : null
+  const [data, setData] = useState(null)
+  const [schema, setSchema] = useState('')
+  const [selectedSchemaType, setSelectedSchemaType] = useState('')
+  const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('')
 
-    const [schemaList, setSchemaList] = useState([]);
+  const [schemaList, setSchemaList] = useState([])
 
-    useEffect(() => {
-        async function fetchSchemaList () {
-            /*
+  useEffect(() => {
+    async function fetchSchemaList () {
+      /*
             Method to retrieve list of schema links from aws s3 bucket
             UseEffect hook so that dropdowns can be rendered from list
             */
-            const schema_links = await fetchSchemasfromS3()
-            const filtered_schemas = filterSchemas(schema_links)
-            setSchemaList(filtered_schemas)
-        }
-        fetchSchemaList();
-    }, []);
-    
-    const typeCallbackFunction = async (childData) => { 
-        /**
+      const schema_links = await fetchSchemasfromS3()
+      const filtered_schemas = filterSchemas(schema_links)
+      setSchemaList(filtered_schemas)
+    }
+    fetchSchemaList()
+  }, [])
+
+  const typeCallbackFunction = async (childData) => {
+    /**
          * Method to retrieve user-selected schema and
          * defaults form to latest version.
          */
-        setSelectedSchemaType(childData)
-        const latestSchemas = findLatestSchemas(schemaList)
-        const schemaURL = latestSchemas[childData].path
-        setSelectedSchemaVersion(latestSchemas[childData].version)
-        await fetchAndSetSchema(schemaURL, childData) 
-    }
+    setSelectedSchemaType(childData)
+    const latestSchemas = findLatestSchemas(schemaList)
+    const schemaURL = latestSchemas[childData].path
+    setSelectedSchemaVersion(latestSchemas[childData].version)
+    await fetchAndSetSchema(schemaURL, childData)
+  }
 
-    const versionCallbackFunction = async (childData) => {
-        /**
+  const versionCallbackFunction = async (childData) => {
+    /**
          * Method to retrieve user-selected schema version
          * and replace default form to selected version
          */
-        setSelectedSchemaVersion(childData)
-        const schemaURL = schemaList.find(url => 
-            url.includes(selectedSchemaType) && url.includes(childData)
-            )
-        await fetchAndSetSchema(schemaURL)
-    }
+    setSelectedSchemaVersion(childData)
+    const schemaURL = schemaList.find(url =>
+      url.includes(selectedSchemaType) && url.includes(childData)
+    )
+    await fetchAndSetSchema(schemaURL)
+  }
 
-    const handleRehydrate =  async () => { 
-        /**
+  const handleRehydrate = async () => {
+    /**
          * Method to put the user-selected data into state
          * updates schema based on schema version in rehydrate file
          */
-        const data = await RehydrateForm()
-        const version = data.schema_version
-        setSelectedSchemaVersion(version)
-        const schemaURL = schemaList.find(url =>
-            url.includes(selectedSchemaType) && url.includes(version))
-        await fetchAndSetSchema(schemaURL)
-        setData(data)
-    }
+    const data = await RehydrateForm()
+    const version = data.schema_version
+    setSelectedSchemaVersion(version)
+    const schemaURL = schemaList.find(url =>
+      url.includes(selectedSchemaType) && url.includes(version))
+    await fetchAndSetSchema(schemaURL)
+    setData(data)
+  }
 
-    const fetchAndSetSchema = async (url) => {
-        /**
+  const fetchAndSetSchema = async (url) => {
+    /**
          * Method to put the user-selected schema into state
          * defaults to latest schema version
          */
-        try {
-            const response = await fetch(process.env.REACT_APP_S3_URL+'/'+url);
-            const schema = await response.json();
-            const processedSchema = await schema ? preProcessSchema(schema) : undefined;
-            setSchema(processedSchema);
-        } catch (error) {
-            console.error(error);
-            toast.error(`Unable to render ${url}`);
-        }
+    try {
+      const response = await fetch(process.env.REACT_APP_S3_URL + '/' + url)
+      const schema = await response.json()
+      const processedSchema = await schema ? preProcessSchema(schema) : undefined
+      setSchema(processedSchema)
+    } catch (error) {
+      console.error(error)
+      toast.error(`Unable to render ${url}`)
     }
+  }
 
-    return (
+  return (
         <div>
             <div className={styles.titleSection}>
                 <h1> AIND Metadata Entry </h1>
                 <div>User-interface for metadata ingestion and validation. Use on Chrome or Edge. {appVersionMsg}</div>
             </div>
             <div className={styles.toolbarSection}>
-                < Toolbar 
+                < Toolbar
                     ParentTypeCallback={typeCallbackFunction}
                     ParentVersionCallback={versionCallbackFunction}
                     selectedSchemaVersion={selectedSchemaVersion}
@@ -106,8 +106,8 @@ export default function App(props) {
                 />
             </div>
             <div className={styles.formSection}>
-                <RenderForm schema={schema} data={data} selectedSchemaType={selectedSchemaType}/> 
+                <RenderForm schema={schema} data={data} selectedSchemaType={selectedSchemaType}/>
             </div>
         </div>
-    );
-};
+  )
+}

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -29,9 +29,9 @@ export default function App (props) {
             Method to retrieve list of schema links from aws s3 bucket
             UseEffect hook so that dropdowns can be rendered from list
             */
-      const schema_links = await fetchSchemasfromS3()
-      const filtered_schemas = filterSchemas(schema_links)
-      setSchemaList(filtered_schemas)
+      const schemaLinks = await fetchSchemasfromS3()
+      const filteredSchemas = filterSchemas(schemaLinks)
+      setSchemaList(filteredSchemas)
     }
     fetchSchemaList()
   }, [])

--- a/src/components/RehydrateForm.js
+++ b/src/components/RehydrateForm.js
@@ -1,26 +1,25 @@
-import 'bootstrap/dist/css/bootstrap.min.css';
+import 'bootstrap/dist/css/bootstrap.min.css'
 
 export default async function RehydrateForm (props) {
-    /*
+  /*
     Functional component to pre-fill form with user-selected data file
         Uses file system access API to access local files
         Returns pre-existing data (JSON object)
     */
-    alert("Select a JSON file from local file system that matches selected schema.")
-    let fileHandle;
-    let formData = null;
+  alert('Select a JSON file from local file system that matches selected schema.')
+  let fileHandle
+  let formData = null
 
-    async function getData() {
-        /*
+  async function getData () {
+    /*
         File system access API to fetch metadata
         */
-        [fileHandle] = await window.showOpenFilePicker();
-        const file = await fileHandle.getFile();
-        const contents = await file.text();
-        return contents;
-    };
+    [fileHandle] = await window.showOpenFilePicker()
+    const file = await fileHandle.getFile()
+    const contents = await file.text()
+    return contents
+  }
 
-    formData = await getData();
-    return JSON.parse(formData);
+  formData = await getData()
+  return JSON.parse(formData)
 }
-

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import Form from '@rjsf/core'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import validator from '@rjsf/validator-ajv8'

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -1,21 +1,22 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 import Form from '@rjsf/core'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import validator from '@rjsf/validator-ajv8'
 import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
 
-export default function RenderForm (props) {
+function RenderForm (props) {
   /*
   Method to read and render a form based on the user-selected schema
-  Arguements:
+  Arguments:
+    props.schemaType (string) = the selected schema type
     props.schema (object) = the selected schema
+    props.formData (object) = the form data
   Returns:
     Form object
   */
-  const schemaName = props.selectedSchemaType
-  const schema = props.schema
-  const formData = props.data
+  const { schemaType, schema, formData } = props
 
   async function saveFilePicker (event) {
     /*
@@ -24,7 +25,7 @@ export default function RenderForm (props) {
     const data = event.formData
     const fileData = JSON.stringify(data, undefined, 4)
     const opts = {
-      suggestedName: `${schemaName}.json`,
+      suggestedName: `${schemaType}.json`,
       types: [
         {
           description: 'JSON file',
@@ -47,9 +48,17 @@ export default function RenderForm (props) {
         widgets={widgets}
         onSubmit={saveFilePicker}
         noHtml5Validate >
-        </Form>
+      </Form>
     )
   } else {
     return (<div> Please select a schema from the dropdown above. </div>)
   }
 }
+
+RenderForm.propTypes = {
+  schemaType: PropTypes.string.isRequired,
+  schema: PropTypes.object,
+  formData: PropTypes.object
+}
+
+export default RenderForm

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -1,55 +1,54 @@
-import Form from '@rjsf/core';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import validator from '@rjsf/validator-ajv8';
-import { widgets } from '../custom-ui/CustomWidgets';
-import { uiSchema } from '../custom-ui/CustomUISchema';
+import Form from '@rjsf/core'
+import 'bootstrap/dist/css/bootstrap.min.css'
+import validator from '@rjsf/validator-ajv8'
+import { widgets } from '../custom-ui/CustomWidgets'
+import { uiSchema } from '../custom-ui/CustomUISchema'
 
 export default function RenderForm (props) {
   /*
   Method to read and render a form based on the user-selected schema
   Arguements:
     props.schema (object) = the selected schema
-  Returns: 
-    Form object 
+  Returns:
+    Form object
   */
-  const schemaName = props.selectedSchemaType;
-  const schema = props.schema;
-  const formData = props.data;
+  const schemaName = props.selectedSchemaType
+  const schema = props.schema
+  const formData = props.data
 
   async function saveFilePicker (event) {
     /*
     File system access API to select save location
     */
-   const data = event.formData;
-   const fileData = JSON.stringify(data, undefined, 4);
-   const opts = {
-    suggestedName: `${schemaName}.json`,
-    types: [
-      {
-        description: "JSON file",
-        accept: {"text/plain": [".json"]}
-      }
-    ]
-   }
-   const handle = await window.showSaveFilePicker(opts);
-   const writer = await handle.createWritable();
-   await writer.write(new Blob([fileData], {type: "text/plain"}));
-   writer.close();
+    const data = event.formData
+    const fileData = JSON.stringify(data, undefined, 4)
+    const opts = {
+      suggestedName: `${schemaName}.json`,
+      types: [
+        {
+          description: 'JSON file',
+          accept: { 'text/plain': ['.json'] }
+        }
+      ]
+    }
+    const handle = await window.showSaveFilePicker(opts)
+    const writer = await handle.createWritable()
+    await writer.write(new Blob([fileData], { type: 'text/plain' }))
+    writer.close()
   }
 
-  if(schema){
-      return (
-        schema && <Form schema={schema}
+  if (schema) {
+    return (
+      schema && <Form schema={schema}
         formData={formData}
         validator={validator}
         uiSchema={uiSchema}
         widgets={widgets}
-        onSubmit={saveFilePicker} 
+        onSubmit={saveFilePicker}
         noHtml5Validate >
         </Form>
-      );
-
- } else {
-  return(<div> Please select a schema from the dropdown above. </div>)
- }
+    )
+  } else {
+    return (<div> Please select a schema from the dropdown above. </div>)
+  }
 }

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,47 +1,47 @@
-import React, { useState } from 'react';
-import 'bootstrap/dist/css/bootstrap.min.css';
-import {compareVersions} from 'compare-versions';
-import styles from './Toolbar.module.css';
+import React, { useState } from 'react'
+import 'bootstrap/dist/css/bootstrap.min.css'
+import { compareVersions } from 'compare-versions'
+import styles from './Toolbar.module.css'
 
 export default function Toolbar (props) {
-    /**
+  /**
      * Component to render a dropdown menu for schema-selection.
-     * Based on selected schema, renders a dropdown menu for version-selection. 
+     * Based on selected schema, renders a dropdown menu for version-selection.
      * Gives user the option to autofill the form with previously input data
      */
-  const [selectedSchemaType, setSelectedSchemaType] = useState('');
-  
+  const [selectedSchemaType, setSelectedSchemaType] = useState('')
+
   const schemaList = props.schemaList
 
   const schemaTypes = Array.from(
     new Set(schemaList.map((schema) => schema.split('/')[1]))
-  );
+  )
   schemaTypes.shift()
 
   const versions = schemaList
-  .filter((schema) => {
-    const [, schemaType] = schema.split('/');
-    return schemaType === selectedSchemaType;
-  })
+    .filter((schema) => {
+      const [, schemaType] = schema.split('/')
+      return schemaType === selectedSchemaType
+    })
     .map((schema) => schema.split('/')[2])
     .filter((version) => version !== undefined)
     .sort(compareVersions)
-    .reverse();
+    .reverse()
 
   const handleTypeChange = (event) => {
-    props.ParentTypeCallback(event.target.value);
-    setSelectedSchemaType(event.target.value);
-  };
+    props.ParentTypeCallback(event.target.value)
+    setSelectedSchemaType(event.target.value)
+  }
 
   const handleVersionChange = (event) => {
-    props.ParentVersionCallback(event.target.value);
-  };
+    props.ParentVersionCallback(event.target.value)
+  }
 
   return (
     <div>
       <select
         id="schema-type-select"
-        className={["btn", "btn-default", styles.dropdown].join(" ")}
+        className={['btn', 'btn-default', styles.dropdown].join(' ')}
         title='Select a schema'
         value={selectedSchemaType}
         onChange={handleTypeChange}
@@ -55,7 +55,7 @@ export default function Toolbar (props) {
       </select>
       <select
         id="schema-version-select"
-        className={["btn", "btn-default", styles.dropdown].join(" ")}
+        className={['btn', 'btn-default', styles.dropdown].join(' ')}
         title='Select a version'
         value={props.selectedSchemaVersion}
         onChange={handleVersionChange}
@@ -71,13 +71,12 @@ export default function Toolbar (props) {
       <button
         title="Autofill with existing data"
         type="button"
-        className={["btn", "btn-default", styles.btnRight].join(" ")}
+        className={['btn', 'btn-default', styles.btnRight].join(' ')}
         onClick={props.handleRehydrate}
         disabled={!selectedSchemaType}
       >
         Autofill with existing data
       </button>
     </div>
-  );
-};
-  
+  )
+}

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -1,17 +1,17 @@
 import React, { useState } from 'react'
+import PropTypes from 'prop-types'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { compareVersions } from 'compare-versions'
 import styles from './Toolbar.module.css'
 
-export default function Toolbar (props) {
+function Toolbar (props) {
   /**
      * Component to render a dropdown menu for schema-selection.
      * Based on selected schema, renders a dropdown menu for version-selection.
      * Gives user the option to autofill the form with previously input data
      */
+  const { ParentTypeCallback, ParentVersionCallback, selectedSchemaVersion, schemaList, handleRehydrate } = props
   const [selectedSchemaType, setSelectedSchemaType] = useState('')
-
-  const schemaList = props.schemaList
 
   const schemaTypes = Array.from(
     new Set(schemaList.map((schema) => schema.split('/')[1]))
@@ -29,12 +29,12 @@ export default function Toolbar (props) {
     .reverse()
 
   const handleTypeChange = (event) => {
-    props.ParentTypeCallback(event.target.value)
+    ParentTypeCallback(event.target.value)
     setSelectedSchemaType(event.target.value)
   }
 
   const handleVersionChange = (event) => {
-    props.ParentVersionCallback(event.target.value)
+    ParentVersionCallback(event.target.value)
   }
 
   return (
@@ -57,7 +57,7 @@ export default function Toolbar (props) {
         id="schema-version-select"
         className={['btn', 'btn-default', styles.dropdown].join(' ')}
         title='Select a version'
-        value={props.selectedSchemaVersion}
+        value={selectedSchemaVersion}
         onChange={handleVersionChange}
         disabled={!selectedSchemaType}
       >
@@ -72,7 +72,7 @@ export default function Toolbar (props) {
         title="Autofill with existing data"
         type="button"
         className={['btn', 'btn-default', styles.btnRight].join(' ')}
-        onClick={props.handleRehydrate}
+        onClick={handleRehydrate}
         disabled={!selectedSchemaType}
       >
         Autofill with existing data
@@ -80,3 +80,13 @@ export default function Toolbar (props) {
     </div>
   )
 }
+
+Toolbar.propTypes = {
+  ParentTypeCallback: PropTypes.func.isRequired,
+  ParentVersionCallback: PropTypes.func.isRequired,
+  selectedSchemaVersion: PropTypes.string.isRequired,
+  schemaList: PropTypes.arrayOf(PropTypes.string).isRequired,
+  handleRehydrate: PropTypes.func.isRequired
+}
+
+export default Toolbar

--- a/src/components/Toolbar.test.js
+++ b/src/components/Toolbar.test.js
@@ -1,41 +1,41 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import Toolbar from "./Toolbar";
-import sampleSchemaList from '../testing/sample-schema-list.json';
-import sampleSortedVersionListInstrument from '../testing/sample-sorted-version-list-instrument.json';
+import { render, screen, fireEvent } from '@testing-library/react'
+import Toolbar from './Toolbar'
+import sampleSchemaList from '../testing/sample-schema-list.json'
+import sampleSortedVersionListInstrument from '../testing/sample-sorted-version-list-instrument.json'
 
 const nullCallback = () => { }
 
-describe("Toolbar component", () => {
-  it("renders appropriate inputs on default", () => {
+describe('Toolbar component', () => {
+  it('renders appropriate inputs on default', () => {
     render(<Toolbar
       schemaList={sampleSchemaList}
-    />);
-    expect(screen.getByTitle('Select a schema')).toBeInTheDocument();
-    expect(screen.getByTitle('Select a version')).toBeInTheDocument();
-    expect(screen.getByTitle('Autofill with existing data')).toBeInTheDocument();
-    expect(screen.getByTitle('Select a schema')).toBeEnabled();
-    expect(screen.getByTitle('Select a version')).toBeDisabled();
-    expect(screen.getByTitle('Autofill with existing data')).toBeDisabled();
+    />)
+    expect(screen.getByTitle('Select a schema')).toBeInTheDocument()
+    expect(screen.getByTitle('Select a version')).toBeInTheDocument()
+    expect(screen.getByTitle('Autofill with existing data')).toBeInTheDocument()
+    expect(screen.getByTitle('Select a schema')).toBeEnabled()
+    expect(screen.getByTitle('Select a version')).toBeDisabled()
+    expect(screen.getByTitle('Autofill with existing data')).toBeDisabled()
   })
 
-  it("enables version selection dropdown and autofill/ upload button when a schema type is chosen", () => {
+  it('enables version selection dropdown and autofill/ upload button when a schema type is chosen', () => {
     render(<Toolbar
       ParentTypeCallback={nullCallback}
       schemaList={sampleSchemaList}
-    />);
-    fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } });
-    expect(screen.getByTitle('Select a version')).toBeEnabled();
-    expect(screen.getByTitle('Autofill with existing data')).toBeEnabled();
+    />)
+    fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } })
+    expect(screen.getByTitle('Select a version')).toBeEnabled()
+    expect(screen.getByTitle('Autofill with existing data')).toBeEnabled()
   })
 
-  it("has schema versions sorted by latest-first semantic version", () => {
+  it('has schema versions sorted by latest-first semantic version', () => {
     render(<Toolbar
       ParentTypeCallback={nullCallback}
       schemaList={sampleSchemaList}
-    />);
-    fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } });
+    />)
+    fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } })
 
-    const schemaVersionsList = [...screen.getByTitle('Select a version').options].map((option) => option.text);
-    expect(schemaVersionsList).toStrictEqual(sampleSortedVersionListInstrument);
+    const schemaVersionsList = [...screen.getByTitle('Select a version').options].map((option) => option.text)
+    expect(schemaVersionsList).toStrictEqual(sampleSortedVersionListInstrument)
   })
 })

--- a/src/components/Toolbar.test.js
+++ b/src/components/Toolbar.test.js
@@ -1,3 +1,4 @@
+import React from 'react'
 import { render, screen, fireEvent } from '@testing-library/react'
 import Toolbar from './Toolbar'
 import sampleSchemaList from '../testing/sample-schema-list.json'

--- a/src/components/Toolbar.test.js
+++ b/src/components/Toolbar.test.js
@@ -9,7 +9,11 @@ const nullCallback = () => { }
 describe('Toolbar component', () => {
   it('renders appropriate inputs on default', () => {
     render(<Toolbar
+      ParentTypeCallback={nullCallback}
+      ParentVersionCallback={nullCallback}
+      selectedSchemaVersion=''
       schemaList={sampleSchemaList}
+      handleRehydrate={nullCallback}
     />)
     expect(screen.getByTitle('Select a schema')).toBeInTheDocument()
     expect(screen.getByTitle('Select a version')).toBeInTheDocument()
@@ -22,7 +26,10 @@ describe('Toolbar component', () => {
   it('enables version selection dropdown and autofill/ upload button when a schema type is chosen', () => {
     render(<Toolbar
       ParentTypeCallback={nullCallback}
+      ParentVersionCallback={nullCallback}
+      selectedSchemaVersion=''
       schemaList={sampleSchemaList}
+      handleRehydrate={nullCallback}
     />)
     fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } })
     expect(screen.getByTitle('Select a version')).toBeEnabled()
@@ -32,7 +39,10 @@ describe('Toolbar component', () => {
   it('has schema versions sorted by latest-first semantic version', () => {
     render(<Toolbar
       ParentTypeCallback={nullCallback}
+      ParentVersionCallback={nullCallback}
+      selectedSchemaVersion=''
       schemaList={sampleSchemaList}
+      handleRehydrate={nullCallback}
     />)
     fireEvent.change(screen.getByTitle('Select a schema'), { target: { value: 'instrument' } })
 

--- a/src/custom-ui/CustomUISchema.js
+++ b/src/custom-ui/CustomUISchema.js
@@ -1,6 +1,6 @@
 export const uiSchema = {
-    "ui:options": {
-        timeFormat: "hh:mm:ss",
-        "ui:placeholder": "00:00:00"
-    }
-};
+  'ui:options': {
+    timeFormat: 'hh:mm:ss',
+    'ui:placeholder': '00:00:00'
+  }
+}

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -1,8 +1,8 @@
 import Datetime from 'react-datetime'
 import 'react-datetime/css/react-datetime.css'
 import moment from 'moment'
-import { default as RadioWidget } from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
-import { default as CheckboxWidget } from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
+import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
+import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
 import React from 'react'
 
 const CustomTimeWidget = (props) => {

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -1,15 +1,15 @@
-import Datetime from 'react-datetime';
-import 'react-datetime/css/react-datetime.css';
-import moment from 'moment';
-import {default as RadioWidget} from "@rjsf/material-ui/lib/RadioWidget/RadioWidget";
-import {default as CheckboxWidget} from "@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget";
-import React from 'react';
+import Datetime from 'react-datetime'
+import 'react-datetime/css/react-datetime.css'
+import moment from 'moment'
+import { default as RadioWidget } from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
+import { default as CheckboxWidget } from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
+import React from 'react'
 
 const CustomTimeWidget = (props) => {
-    const onChange = (selectedDate) => {
-        const formattedTime = moment(selectedDate).format('HH:mm:ss');
-        props.onChange(formattedTime);
-      };
+  const onChange = (selectedDate) => {
+    const formattedTime = moment(selectedDate).format('HH:mm:ss')
+    props.onChange(formattedTime)
+  }
   return (
     <Datetime
       dateFormat={false}
@@ -17,26 +17,23 @@ const CustomTimeWidget = (props) => {
       value={props.value ? moment(props.value, 'HH:mm:ss') : undefined}
       onChange={onChange}
     />
-  );
-};
+  )
+}
 
 /**
  * Uses RadioButtons for booleans so
  * users understand undefined default
  */
 const CustomCheckboxWidget = (props) => {
-    if (props.schema.type === "boolean"){
-        return(
-            RadioWidget(props)
-       );
-    } else {
-       return (
-          CheckboxWidget(props)
-       );
-    };
-};
+  if (props.schema.type === 'boolean') {
+    return (
+      RadioWidget(props)
+    )
+  } else {
+    return (
+      CheckboxWidget(props)
+    )
+  }
+}
 
-
-export const widgets = {checkbox: CustomCheckboxWidget, time: CustomTimeWidget};
-
-
+export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
 import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const CustomTimeWidget = (props) => {
   const onChange = (selectedDate) => {
@@ -18,6 +19,10 @@ const CustomTimeWidget = (props) => {
       onChange={onChange}
     />
   )
+}
+CustomTimeWidget.propTypes = {
+  onChange: PropTypes.func,
+  value: PropTypes.any
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -1,22 +1,22 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client'; 
-import App from './components/App';
-import reportWebVitals from './reportWebVitals';
-import { ToastContainer } from 'react-toastify';
-import 'react-toastify/dist/ReactToastify.css';
-import './index.css';
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './components/App'
+import reportWebVitals from './reportWebVitals'
+import { ToastContainer } from 'react-toastify'
+import 'react-toastify/dist/ReactToastify.css'
+import './index.css'
 
-const appVersion = require('../package.json').version;
+const appVersion = require('../package.json').version
 console.log('app version: ', appVersion)
 console.log('s3 url: ', process.env.REACT_APP_S3_URL)
 console.log('schemas to filter: ', process.env.REACT_APP_FILTER_SCHEMAS)
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById('root'))
 root.render(
     <div>
         <App appVersion={appVersion} />
         <ToastContainer autoClose={8000} />
     </div>
-);
+)
 
-reportWebVitals();
+reportWebVitals()

--- a/src/reportWebVitals.js
+++ b/src/reportWebVitals.js
@@ -1,14 +1,13 @@
 const reportWebVitals = onPerfEntry => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    });
+      getCLS(onPerfEntry)
+      getFID(onPerfEntry)
+      getFCP(onPerfEntry)
+      getLCP(onPerfEntry)
+      getTTFB(onPerfEntry)
+    })
   }
-};
+}
 
-export default reportWebVitals;
-
+export default reportWebVitals

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -4,4 +4,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,21 +1,21 @@
 export async function fetchSchemasfromS3 (props) {
-    /*
+  /*
     Method to retrieve list of schema links from aws s3 bucket
     */
 
-    const response = await fetch(process.env.REACT_APP_S3_URL)
-    const responseText = await response.text()
-    const parser=new DOMParser();
-    const xmlParsed = parser.parseFromString(responseText, 'text/xml');
-    var schema_links = []
-    const elements = xmlParsed.getElementsByTagName("Key");
-    for (var i=0; i < elements.length; i++) {
-        schema_links[i] = elements[i].innerHTML
-    }
-    return schema_links
+  const response = await fetch(process.env.REACT_APP_S3_URL)
+  const responseText = await response.text()
+  const parser = new DOMParser()
+  const xmlParsed = parser.parseFromString(responseText, 'text/xml')
+  const schema_links = []
+  const elements = xmlParsed.getElementsByTagName('Key')
+  for (let i = 0; i < elements.length; i++) {
+    schema_links[i] = elements[i].innerHTML
+  }
+  return schema_links
 }
 
-export function filterSchemas(schema_links) {
+export function filterSchemas (schema_links) {
   /*
   Method to filter schemas in schema list options.
    */
@@ -23,45 +23,45 @@ export function filterSchemas(schema_links) {
   if (!filter) { return schema_links }
   const filterArray = JSON.parse(filter)
   const filteredStrings = schema_links.filter(str => !filterArray.some(substring => str.includes(substring)))
-  return filteredStrings;
+  return filteredStrings
 }
 
-export function findLatestSchemas(schemasList) {
-    /*
+export function findLatestSchemas (schemasList) {
+  /*
     Method to find latest version of each schema
     */
-    const latestSchemas = {};
-    for (const schemaPath of schemasList) {
-      const parts = schemaPath.split('/');
-      if (parts[0] === 'schemas') {
-        const schemaType = parts[1];
-        const schemaVersion = parts[2];
-        if (!latestSchemas[schemaType] || compareVersions(schemaVersion, latestSchemas[schemaType].version) > 0) {
-          latestSchemas[schemaType] = {
-            schema_type: schemaType,
-            version: schemaVersion,
-            path: schemaPath
-          };
+  const latestSchemas = {}
+  for (const schemaPath of schemasList) {
+    const parts = schemaPath.split('/')
+    if (parts[0] === 'schemas') {
+      const schemaType = parts[1]
+      const schemaVersion = parts[2]
+      if (!latestSchemas[schemaType] || compareVersions(schemaVersion, latestSchemas[schemaType].version) > 0) {
+        latestSchemas[schemaType] = {
+          schema_type: schemaType,
+          version: schemaVersion,
+          path: schemaPath
         }
       }
     }
-    return latestSchemas;
   }
-  
-  function compareVersions(v1, v2) {
-    /*
+  return latestSchemas
+}
+
+function compareVersions (v1, v2) {
+  /*
     Helper method for to find latest schemas
     */
-    const parts1 = v1.split('.');
-    const parts2 = v2.split('.');
-    for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
-      const part1 = parseInt(parts1[i] || '0');
-      const part2 = parseInt(parts2[i] || '0');
-      if (part1 < part2) {
-        return -1;
-      } else if (part1 > part2) {
-        return 1;
-      }
+  const parts1 = v1.split('.')
+  const parts2 = v2.split('.')
+  for (let i = 0; i < Math.max(parts1.length, parts2.length); i++) {
+    const part1 = parseInt(parts1[i] || '0')
+    const part2 = parseInt(parts2[i] || '0')
+    if (part1 < part2) {
+      return -1
+    } else if (part1 > part2) {
+      return 1
     }
-    return 0;
   }
+  return 0
+}

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -7,22 +7,22 @@ export async function fetchSchemasfromS3 (props) {
   const responseText = await response.text()
   const parser = new DOMParser()
   const xmlParsed = parser.parseFromString(responseText, 'text/xml')
-  const schema_links = []
+  const schemaLinks = []
   const elements = xmlParsed.getElementsByTagName('Key')
   for (let i = 0; i < elements.length; i++) {
-    schema_links[i] = elements[i].innerHTML
+    schemaLinks[i] = elements[i].innerHTML
   }
-  return schema_links
+  return schemaLinks
 }
 
-export function filterSchemas (schema_links) {
+export function filterSchemas (schemaLinks) {
   /*
   Method to filter schemas in schema list options.
    */
   const filter = process.env.REACT_APP_FILTER_SCHEMAS
-  if (!filter) { return schema_links }
+  if (!filter) { return schemaLinks }
   const filterArray = JSON.parse(filter)
-  const filteredStrings = schema_links.filter(str => !filterArray.some(substring => str.includes(substring)))
+  const filteredStrings = schemaLinks.filter(str => !filterArray.some(substring => str.includes(substring)))
   return filteredStrings
 }
 

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -1,140 +1,138 @@
-import {preProcessSchema} from './schemaHandlers';
+import { preProcessSchema } from './schemaHandlers'
 
 const testSchema1 = ({
-    type: "object",
-    properties: {
-        describedBy: {
-            type: "string",
-            const: "https://github.com/AllenNeuralDynamics/data_schema/blob/main/schemas/subject.json",
-            description: "The URL reference to the schema.",
-            title: "Described by"
-        }
+  type: 'object',
+  properties: {
+    describedBy: {
+      type: 'string',
+      const: 'https://github.com/AllenNeuralDynamics/data_schema/blob/main/schemas/subject.json',
+      description: 'The URL reference to the schema.',
+      title: 'Described by'
     }
-});
+  }
+})
 
 const testSchema2 = ({
-    title: "sample schema",
-    type: "object",
-    properties: {
-        name: {
-            title: "Full Name",
-            type: "string",
-        },
-        email: {
-            title: "Email Address",
-            type: "string"
-        },
-        parameters: {
-            title: "parameters",
-            type: "object",
-            default: {}
-        }
+  title: 'sample schema',
+  type: 'object',
+  properties: {
+    name: {
+      title: 'Full Name',
+      type: 'string'
     },
-    required: [
-        "name"
-    ]
-});
+    email: {
+      title: 'Email Address',
+      type: 'string'
+    },
+    parameters: {
+      title: 'parameters',
+      type: 'object',
+      default: {}
+    }
+  },
+  required: [
+    'name'
+  ]
+})
 
 const testSchema3 = ({
-    title: "sample schema",
-    type: "object",
-    properties: {
-        name: {
-            title: "Full Name",
-            type: "string"
+  title: 'sample schema',
+  type: 'object',
+  properties: {
+    name: {
+      title: 'Full Name',
+      type: 'string'
+    },
+    email: {
+      title: 'Email Address',
+      anyOf: [
+        {
+          type: 'string'
         },
-        email: {
-            title: "Email Address",
-            anyOf: [
-                {
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ]
-        }, 
-        resume: {
-            title: "Resume",
-            type: "object",
-            properties: {
-                education: {
-                    title: "Education",
-                    const: "Farmington University",
-                    type: "string"
-                },
-                past_experiences: {
-                    title: "Past Experiences",
-                    type: "array",
-                    items: {
-                        $ref: "#/definitions/PastExperience"
-                    }
-                }
-            }
+        {
+          type: 'null'
         }
+      ]
     },
-    definitions: {
-        PastExperience: {
-            title: "PastExperience",
-            description: "Description of Past Experience",
-            type: "object",
-            key_points: {
-                title: "Key Points",
-                description: "Info about job experience (ex: company name, duration, etc)",
-                type: "object",
-                default: {}
-            }
+    resume: {
+      title: 'Resume',
+      type: 'object',
+      properties: {
+        education: {
+          title: 'Education',
+          const: 'Farmington University',
+          type: 'string'
+        },
+        past_experiences: {
+          title: 'Past Experiences',
+          type: 'array',
+          items: {
+            $ref: '#/definitions/PastExperience'
+          }
         }
-    },
-    required: [
-        "name"
-    ]
-});
-
+      }
+    }
+  },
+  definitions: {
+    PastExperience: {
+      title: 'PastExperience',
+      description: 'Description of Past Experience',
+      type: 'object',
+      key_points: {
+        title: 'Key Points',
+        description: 'Info about job experience (ex: company name, duration, etc)',
+        type: 'object',
+        default: {}
+      }
+    }
+  },
+  required: [
+    'name'
+  ]
+})
 
 const testSchema4 = ({
-    title: "sample schema",
-    type: "object",
-    properties: {
-        name: {
-            title: "Full Name",
-            type: "string"
-        },
-        email: {
-            title: "Email Address",
-            type: "string"
-        }
+  title: 'sample schema',
+  type: 'object',
+  properties: {
+    name: {
+      title: 'Full Name',
+      type: 'string'
     },
-    required: [
-        "name"
-    ]
-});
-
-test("Checks preProcessSchema modifies const schema", () => {
-    const processedSchema1 = preProcessSchema(testSchema1);
-    expect(processedSchema1.properties.describedBy.default).toBe(testSchema1.properties.describedBy.const);
-    expect(processedSchema1.properties.describedBy.readOnly).toBe(true);
+    email: {
+      title: 'Email Address',
+      type: 'string'
+    }
+  },
+  required: [
+    'name'
+  ]
 })
 
-test("Checks preProcessSchema modifies dictionary additional properties", () => {
-    const processedSchema2 = preProcessSchema(testSchema2);
-    expect(processedSchema2.properties.parameters.additionalProperties).toStrictEqual({"type": "string"})
+test('Checks preProcessSchema modifies const schema', () => {
+  const processedSchema1 = preProcessSchema(testSchema1)
+  expect(processedSchema1.properties.describedBy.default).toBe(testSchema1.properties.describedBy.const)
+  expect(processedSchema1.properties.describedBy.readOnly).toBe(true)
 })
 
-test("Checks preProcessSchema add default title to `anyOf` options if needed", () => {
-    const processedSchema3 = preProcessSchema(testSchema3);
-    expect(processedSchema3.properties.email.anyOf).toStrictEqual([{ "title": "string", "type": "string" }, { "title": "null", "type": "null" }])
+test('Checks preProcessSchema modifies dictionary additional properties', () => {
+  const processedSchema2 = preProcessSchema(testSchema2)
+  expect(processedSchema2.properties.parameters.additionalProperties).toStrictEqual({ type: 'string' })
 })
 
-
-test("Checks preProcessSchema recurses through nested schema as expected", () => {
-    const processedSchema3 = preProcessSchema(testSchema3);
-    expect(processedSchema3.properties.resume.properties.education.readOnly).toBe(true);
-    expect(processedSchema3.properties.resume.properties.education.default).toBe(testSchema3.properties.resume.properties.education.const);
-    expect(processedSchema3.definitions.PastExperience.key_points.additionalProperties).toStrictEqual({"type": "string"})
+test('Checks preProcessSchema add default title to `anyOf` options if needed', () => {
+  const processedSchema3 = preProcessSchema(testSchema3)
+  expect(processedSchema3.properties.email.anyOf).toStrictEqual([{ title: 'string', type: 'string' }, { title: 'null', type: 'null' }])
 })
 
-test("Checks preProcessSchema does not modify simple sample schema", () => {
-    const processedSchema = preProcessSchema(testSchema4);
-    expect(processedSchema).toEqual(testSchema4);
+test('Checks preProcessSchema recurses through nested schema as expected', () => {
+  const processedSchema3 = preProcessSchema(testSchema3)
+  expect(processedSchema3.properties.resume.properties.education.readOnly).toBe(true)
+  expect(processedSchema3.properties.resume.properties.education.default).toBe(testSchema3.properties.resume.properties.education.const)
+  expect(processedSchema3.definitions.PastExperience.key_points.additionalProperties).toStrictEqual({ type: 'string' })
+})
+
+test('Checks preProcessSchema does not modify simple sample schema', () => {
+  const processedSchema = preProcessSchema(testSchema4)
+  expect(processedSchema).toEqual(testSchema4)
 })

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,7 +1,7 @@
-import { toast } from 'react-toastify';
+import { toast } from 'react-toastify'
 
 const preProcessHelper = (obj) => {
-  /* 
+  /*
   Recursively iterates through schema for rendering purposes
     Makes const fields non-fillable
     Renders dictionaries
@@ -9,17 +9,17 @@ const preProcessHelper = (obj) => {
   */
   Object.keys(obj).forEach(key => {
     if (obj[key] !== null) {
-      const prop = obj[key];
+      const prop = obj[key]
 
       // grays out const fields (readOnly) and autofills the field with the const value (default)
       if (prop.const !== undefined) {
-        prop.readOnly = true;
-        prop.default = prop.const;
+        prop.readOnly = true
+        prop.default = prop.const
       }
 
-      // if default is {}, expected value is a dictionary of strings 
+      // if default is {}, expected value is a dictionary of strings
       if (prop.default && typeof (prop.default) === 'object' && Object.keys(prop.default).length === 0) {
-        prop.additionalProperties = { "type": "string" }
+        prop.additionalProperties = { type: 'string' }
       }
 
       // add default titles to dropdown of allowed types/ subschemas
@@ -36,11 +36,11 @@ const preProcessHelper = (obj) => {
 
       // recursion
       if (typeof (prop) === 'object') {
-        preProcessHelper(prop);
+        preProcessHelper(prop)
       }
     }
-  });
-};
+  })
+}
 
 export const preProcessSchema = (schema) => {
   /*
@@ -48,7 +48,7 @@ export const preProcessSchema = (schema) => {
     Uses helper function to make const fields non-fillable
     Returns processedSchema if successful, otherwise returns raw original schema
   */
-  let copiedSchema = JSON.parse(JSON.stringify(schema))
+  const copiedSchema = JSON.parse(JSON.stringify(schema))
   try {
     preProcessHelper(copiedSchema)
   } catch (error) {
@@ -58,5 +58,5 @@ export const preProcessSchema = (schema) => {
     toast.warn(`${msg}. Rendered raw schema instead.`)
     return schema
   }
-  return copiedSchema;
+  return copiedSchema
 }


### PR DESCRIPTION
closes #27 

- Configured [Jest](https://jestjs.io) test runner with [React Testing Library](https://testing-library.com/docs/react-testing-library/intro)
    - use `npm run test:coverage` or `npm run test` (watch mode)
    - configured coverage thresholds to current coverage
- Added and configured [ESLint](https://eslint.org/docs/latest/use/core-concepts) for React, with [JS Standard Code Style](https://standardjs.com/rules)
    - use `npm run lint` or `npm run lint:fix` (auto-fixes issues)
    - fixed all current linting errors
 - Updated `README.md` as appropriate

NOTE: there will be future tickets to increase test coverage to 100%, add pre-commit/ pre-push Git hooks to enforce linter and unit tests, and add GitHub Actions to enforce the same on PRs