### PR TITLE
Fix 131: Enforce re-render and handle errors in `RenderForm` component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "jquery": "^3.7.1",
         "react-bootstrap": "^2.8.0",
         "react-datetime": "^3.2.0",
+        "react-error-boundary": "^4.0.12",
         "react-router-dom": "^6.16.0",
         "react-toastify": "^10.0.4",
         "web-vitals": "^2.1.4"
@@ -17869,6 +17870,17 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
     "node_modules/react-error-overlay": {
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
@@ -35366,6 +35378,14 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
+      }
+    },
+    "react-error-boundary": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.12.tgz",
+      "integrity": "sha512-kJdxdEYlb7CPC1A0SeUY38cHpjuu6UkvzKiAmqmOFL21VRfMhOcWxTCBgLVCO0VEMh9JhFNcVaXlV4/BTpiwOA==",
+      "requires": {
+        "@babel/runtime": "^7.12.5"
       }
     },
     "react-error-overlay": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "jquery": "^3.7.1",
     "react-bootstrap": "^2.8.0",
     "react-datetime": "^3.2.0",
+    "react-error-boundary": "^4.0.12",
     "react-router-dom": "^6.16.0",
     "react-toastify": "^10.0.4",
     "web-vitals": "^2.1.4"

--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 22,
-        "branches": 29,
-        "functions": 32,
-        "lines": 23
+        "statements": 32,
+        "branches": 31,
+        "functions": 44,
+        "lines": 33
       }
     }
   },

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -23,6 +23,7 @@ function App (props) {
   const [schema, setSchema] = useState(null)
   const [selectedSchemaType, setSelectedSchemaType] = useState('')
   const [selectedSchemaVersion, setSelectedSchemaVersion] = useState('')
+  const [selectedSchemaPath, setSelectedSchemaPath] = useState('')
 
   const [schemaList, setSchemaList] = useState([])
 
@@ -86,6 +87,7 @@ function App (props) {
       const response = await fetch(process.env.REACT_APP_S3_URL + '/' + url)
       const schema = await response.json()
       const processedSchema = await schema ? preProcessSchema(schema) : undefined
+      setSelectedSchemaPath(url)
       setSchema(processedSchema)
     } catch (error) {
       console.error(error)
@@ -112,9 +114,9 @@ function App (props) {
         <ErrorBoundary
           fallback={<div className={styles.error}>Unable to render form. Please try again or select a different schema/version.</div>}
           onError={(error) => { toast.error(`${error.name}: ${error.message}`) }}
-          resetKeys={[schema]}
+          resetKeys={[selectedSchemaPath]}
         >
-          <RenderForm schemaType={selectedSchemaType} schema={schema} formData={data} />
+          <RenderForm key={selectedSchemaPath} schemaType={selectedSchemaType} schema={schema} formData={data} />
         </ErrorBoundary>
       </div>
     </div>

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import PropTypes from 'prop-types'
+import { ErrorBoundary } from 'react-error-boundary'
 import { toast } from 'react-toastify'
 import RenderForm from './RenderForm'
 import RehydrateForm from './RehydrateForm'
@@ -108,7 +109,13 @@ function App (props) {
         />
       </div>
       <div className={styles.formSection}>
-        <RenderForm schemaType={selectedSchemaType} schema={schema} formData={data} />
+        <ErrorBoundary
+          fallback={<div className={styles.error}>Unable to render form. Please try again or select a different schema/version.</div>}
+          onError={(error) => { toast.error(`${error.name}: ${error.message}`) }}
+          resetKeys={[schema]}
+        >
+          <RenderForm schemaType={selectedSchemaType} schema={schema} formData={data} />
+        </ErrorBoundary>
       </div>
     </div>
   )

--- a/src/components/App.js
+++ b/src/components/App.js
@@ -112,7 +112,7 @@ function App (props) {
       </div>
       <div className={styles.formSection}>
         <ErrorBoundary
-          fallback={<div className={styles.error}>Unable to render form. Please try again or select a different schema/version.</div>}
+          fallback={<div title='Form error' className={styles.error}>Unable to render form. Please try again or select a different schema/version.</div>}
           onError={(error) => { toast.error(`${error.name}: ${error.message}`) }}
           resetKeys={[selectedSchemaPath]}
         >

--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -16,5 +16,9 @@ body {
     .formSection {
         padding: 15px;
         border: 1px dashed grey;
+
+        .error {
+            color: red;
+        }
     }
 }

--- a/src/components/App.test.js
+++ b/src/components/App.test.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import App from './App'
+import Toolbar from './Toolbar'
+import RenderForm from './RenderForm'
+
+const testAppVersion = '0.1.0'
+jest.mock('./Toolbar', () => jest.fn())
+jest.mock('./RenderForm', () => jest.fn())
+
+describe('App component', () => {
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('renders without crashing', () => {
+    render(<App appVersion={testAppVersion} />)
+    expect(screen.queryByTitle('Form error')).toBeNull()
+  })
+
+  it('renders Toolbar and RenderForm child components on default', () => {
+    render(<App appVersion={testAppVersion} />)
+    expect(Toolbar).toHaveBeenCalled()
+    expect(RenderForm).toHaveBeenCalled()
+  })
+
+  it('catches and displays error when unable to render form', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => jest.fn())
+    RenderForm.mockImplementation(() => { throw new Error('Unable to render form') })
+    render(<App appVersion={testAppVersion} />)
+    expect(RenderForm).toThrow('Unable to render form')
+    expect(screen.getByTitle('Form error')).toBeVisible()
+  })
+})


### PR DESCRIPTION
closes #131

Resolve unhandled errors caused by incorrect state handling in the `RenderForm` component:
- Add [`ErrorBoundary`](https://www.npmjs.com/package/react-error-boundary) within `App.js` to catch and display errors from `RenderForm` component.
- Use `selectedSchemaPath` as `key` prop to `RenderForm` component. This enforces that the form is cleared and re-rendered on changes to selected schema/version.
- Added new unit tests for `App` component as necessary.

![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/701a5057-dfbc-4791-b1aa-e22ba516bd3f)
![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/0f9e38ba-caed-401d-a66f-719e4d2a6cac)



