### PR TITLE
Feat 68: Add border-left css for nested form fieldsets

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,17 @@
 body {
-  max-width: 80%;
+  max-width: 90%;
   margin: auto;
   --toastify-toast-width: 400px;
+}
+
+Form fieldset {
+  padding-left: 8px;
+  border-left: 2px solid rgba(0, 0, 255, .25);
+  border-radius: 5px;
+
+  &:hover {
+      border-color: rgba(0, 0, 255, .5);
+  }
 }
 
 div.form-group.field.field-integer {


### PR DESCRIPTION
closes #68
- Add extra indent and vertical bar/ left-border to indicate nested schemas
<img width="547" alt="solid" src="https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/4c4a42d2-adaa-4a81-aaf0-1e8868d6b835">
