### PR TITLE
Fix 139: Enable validation for discriminator keyword

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 41,
-        "branches": 52,
+        "statements": 42,
+        "branches": 53,
         "functions": 52,
-        "lines": 42
+        "lines": 43
       }
     }
   },

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -49,6 +49,8 @@ function RenderForm (props) {
         uiSchema={uiSchema}
         widgets={widgets}
         onSubmit={saveFilePicker}
+        omitExtraData
+        liveOmit
         noHtml5Validate >
       </Form>
     )

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -2,9 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Form from '@rjsf/core'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import validator from '@rjsf/validator-ajv8'
+import { customizeValidator } from '@rjsf/validator-ajv8'
 import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
+import { AJV_OPTIONS } from '../utilities/schemaHandlers'
 
 function RenderForm (props) {
   /*
@@ -17,6 +18,7 @@ function RenderForm (props) {
     Form object
   */
   const { schemaType, schema, formData } = props
+  const validator = customizeValidator(AJV_OPTIONS)
 
   async function saveFilePicker (event) {
     /*

--- a/src/testing/sample-schema-discriminator.json
+++ b/src/testing/sample-schema-discriminator.json
@@ -1,0 +1,124 @@
+{
+  "$defs": {
+    "Option1": {
+      "additionalProperties": false,
+      "description": "Description of Option1",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option1",
+          "default": "Option1",
+          "title": "Discriminator 1"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option1",
+      "type": "object"
+    },
+    "Option2": {
+      "additionalProperties": false,
+      "description": "Description of Option2",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option2",
+          "default": "Option2",
+          "title": "Discriminator 2"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option2",
+      "type": "object"
+    },
+    "Option3": {
+      "additionalProperties": false,
+      "description": "Description of Option3",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option3",
+          "default": "Option3",
+          "title": "Discriminator 3"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option3",
+      "type": "object"
+    },
+    "Option4": {
+      "additionalProperties": false,
+      "description": "Description of Option4",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option4",
+          "default": "Option4",
+          "title": "Discriminator 4"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option4",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Sample schema with subschema with discriminator keyword.",
+  "properties": {
+    "schema_version": {
+      "const": "0.0.1",
+      "default": "0.0.1",
+      "title": "Schema Version"
+    },
+    "sub_schema": {
+      "discriminator": {
+        "mapping": {
+          "Option1": "#/$defs/Option1",
+          "Option2": "#/$defs/Option2",
+          "Option3": "#/$defs/Option3",
+          "Option4": "#/$defs/Option4"
+        },
+        "propertyName": "discriminator_property"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Option1"
+        },
+        {
+          "$ref": "#/$defs/Option4"
+        },
+        {
+          "$ref": "#/$defs/Option3"
+        },
+        {
+          "$ref": "#/$defs/Option2"
+        }
+      ],
+      "title": "Sub Schema with Discriminator Keyword"
+    }
+  },
+  "required": [
+    "sub_schema"
+  ],
+  "title": "Sample Schema with Discriminator",
+  "type": "object"
+}

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -1,4 +1,5 @@
 import { preProcessSchema } from './schemaHandlers'
+import SAMPLE_SCHEMA_DISCRIMINATOR from '../testing/sample-schema-discriminator.json'
 
 const testSchema1 = ({
   type: 'object',
@@ -120,9 +121,19 @@ test('Checks preProcessSchema modifies dictionary additional properties', () => 
   expect(processedSchema2.properties.parameters.additionalProperties).toStrictEqual({ type: 'string' })
 })
 
-test('Checks preProcessSchema add default title to `anyOf` options if needed', () => {
+test('Checks preProcessSchema adds default title to `anyOf` options if needed', () => {
   const processedSchema3 = preProcessSchema(testSchema3)
   expect(processedSchema3.properties.email.anyOf).toStrictEqual([{ title: 'string', type: 'string' }, { title: 'null', type: 'null' }])
+})
+
+test('Checks preProcessSchema removes discriminator.mapping property', () => {
+  const processedSchema = preProcessSchema(SAMPLE_SCHEMA_DISCRIMINATOR)
+  expect(processedSchema.properties.sub_schema.discriminator.mapping).toBe(undefined)
+})
+
+test('Checks preProcessSchema adds discriminator property as required', () => {
+  const processedSchema = preProcessSchema(SAMPLE_SCHEMA_DISCRIMINATOR)
+  expect(processedSchema.properties.sub_schema.required).toStrictEqual([SAMPLE_SCHEMA_DISCRIMINATOR.properties.sub_schema.discriminator.propertyName])
 })
 
 test('Checks preProcessSchema recurses through nested schema as expected', () => {

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,11 +1,18 @@
 import { toast } from 'react-toastify'
 
+export const AJV_OPTIONS = {
+  ajvOptionsOverrides: {
+    discriminator: true
+  }
+}
+
 const preProcessHelper = (obj) => {
   /*
   Recursively iterates through schema for rendering purposes
     Makes const fields non-fillable
     Renders dictionaries
     Displays type selection dropdown with better default text
+    Enables validation for discriminator keyword
   */
   Object.keys(obj).forEach(key => {
     if (obj[key] !== null) {
@@ -32,6 +39,18 @@ const preProcessHelper = (obj) => {
             option.title = option.type
           }
         })
+      }
+
+      // enable validation for discriminator keyword
+      if (AJV_OPTIONS.ajvOptionsOverrides.discriminator && prop.discriminator) {
+        // discriminator.mapping is not supported and discriminator property must be `required`
+        // docs: https://ajv.js.org/json-schema.html#discriminator
+        delete prop.discriminator.mapping
+        if (!prop.required) {
+          prop.required = [prop.discriminator.propertyName]
+        } else if (!prop.required.includes(prop.discriminator.propertyName)) {
+          prop.required.push(prop.discriminator.propertyName)
+        }
       }
 
       // recursion


### PR DESCRIPTION
closes #139
1. Enabled `discriminator` validation in the JSON Schema validator.
    - This ensures that validation is only done against selected option rather than all `oneOf` options (resolves the repeated errors for all fields).
    - Added pre-processing to conform to Ajv validator requirements ([docs](https://ajv.js.org/json-schema.html#discriminator)).
2. Enabled `liveOmit` and `omitExtraData` in the RJSF props ([docs](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/form-props/#liveomit)).
    - This ensures that extra formData is not preserved when the selected option is changed (resolves the repeated `must NOT have additional properties` errors).
3. Added unit tests as appropriate.
