### PR TITLE
Fix 139: Enable discriminator support in validator and fix validation errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 41,
-        "branches": 52,
+        "statements": 44,
+        "branches": 54,
         "functions": 52,
-        "lines": 42
+        "lines": 44
       }
     }
   },

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -49,6 +49,8 @@ function RenderForm (props) {
         uiSchema={uiSchema}
         widgets={widgets}
         onSubmit={saveFilePicker}
+        omitExtraData
+        liveOmit
         noHtml5Validate >
       </Form>
     )

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -2,9 +2,10 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Form from '@rjsf/core'
 import 'bootstrap/dist/css/bootstrap.min.css'
-import validator from '@rjsf/validator-ajv8'
+import { customizeValidator } from '@rjsf/validator-ajv8'
 import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
+import { AJV_OPTIONS } from '../utilities/schemaHandlers'
 
 function RenderForm (props) {
   /*
@@ -17,6 +18,7 @@ function RenderForm (props) {
     Form object
   */
   const { schemaType, schema, formData } = props
+  const validator = customizeValidator(AJV_OPTIONS)
 
   async function saveFilePicker (event) {
     /*

--- a/src/testing/sample-schema-discriminator.json
+++ b/src/testing/sample-schema-discriminator.json
@@ -1,0 +1,145 @@
+{
+  "$defs": {
+    "Option1": {
+      "additionalProperties": false,
+      "description": "Description of Option1",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option1",
+          "default": "Option1",
+          "title": "Discriminator 1"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option1",
+      "type": "object"
+    },
+    "Option2": {
+      "additionalProperties": false,
+      "description": "Description of Option2",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option2",
+          "default": "Option2",
+          "title": "Discriminator 2"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option2",
+      "type": "object"
+    },
+    "Option3": {
+      "additionalProperties": false,
+      "description": "Description of Option3",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option3",
+          "default": "Option3",
+          "title": "Discriminator 3"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option3",
+      "type": "object"
+    },
+    "Option4": {
+      "additionalProperties": false,
+      "description": "Description of Option4",
+      "properties": {
+        "discriminator_property": {
+          "const": "Option4",
+          "default": "Option4",
+          "title": "Discriminator 4"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "Option4",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Sample schema with subschema with discriminator keyword.",
+  "properties": {
+    "schema_version": {
+      "const": "0.0.1",
+      "default": "0.0.1",
+      "title": "Schema Version"
+    },
+    "sub_schema": {
+      "discriminator": {
+        "mapping": {
+          "Option1": "#/$defs/Option1",
+          "Option2": "#/$defs/Option2",
+          "Option3": "#/$defs/Option3",
+          "Option4": "#/$defs/Option4"
+        },
+        "propertyName": "discriminator_property"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Option1"
+        },
+        {
+          "$ref": "#/$defs/Option4"
+        },
+        {
+          "$ref": "#/$defs/Option3"
+        },
+        {
+          "$ref": "#/$defs/Option2"
+        }
+      ],
+      "title": "Sub Schema with Discriminator Keyword"
+    },
+    "sub_schema_required": {
+      "discriminator": {
+        "mapping": {
+          "Option1": "#/$defs/Option1",
+          "Option2": "#/$defs/Option2"
+        },
+        "propertyName": "discriminator_property"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Option1"
+        },
+        {
+          "$ref": "#/$defs/Option4"
+        }
+      ],
+      "required": [
+        "name"
+      ],
+      "title": "Sub Schema with Discriminator and Required Property"
+    }
+  },
+  "required": [
+    "sub_schema"
+  ],
+  "title": "Sample Schema with Discriminator",
+  "type": "object"
+}

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -25,7 +25,7 @@ const preProcessHelper = (obj) => {
       }
 
       // if default is {}, expected value is a dictionary of strings
-      if (prop.default && typeof (prop.default) === 'object' && Object.keys(prop.default).length === 0) {
+      if (JSON.stringify(prop.default) === '{}') {
         prop.additionalProperties = { type: 'string' }
       }
 

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,11 +1,18 @@
 import { toast } from 'react-toastify'
 
+export const AJV_OPTIONS = {
+  ajvOptionsOverrides: {
+    discriminator: true
+  }
+}
+
 const preProcessHelper = (obj) => {
   /*
   Recursively iterates through schema for rendering purposes
     Makes const fields non-fillable
     Renders dictionaries
     Displays type selection dropdown with better default text
+    Enables validation for discriminator keyword
   */
   Object.keys(obj).forEach(key => {
     if (obj[key] !== null) {
@@ -32,6 +39,18 @@ const preProcessHelper = (obj) => {
             option.title = option.type
           }
         })
+      }
+
+      // enable validation for discriminator keyword
+      if (AJV_OPTIONS.ajvOptionsOverrides.discriminator && prop.discriminator) {
+        // discriminator.mapping is not supported and discriminator property must be `required`
+        // docs: https://ajv.js.org/json-schema.html#discriminator
+        delete prop.discriminator.mapping
+        if (!prop.required) {
+          prop.required = [prop.discriminator.propertyName]
+        } else if (!prop.required.includes(prop.discriminator.propertyName)) {
+          prop.required.push(prop.discriminator.propertyName)
+        }
       }
 
       // recursion


### PR DESCRIPTION
closes #139
1. Enabled `discriminator` support in the JSON Schema validator so that validation is only done against currently selected option.
    - This resolves the "multiple errors for all fields" issue since validator was previously comparing against all possible options.
2. Enabled `liveOmit` and `omitExtraData` in the RJSF props ([docs](https://rjsf-team.github.io/react-jsonschema-form/docs/api-reference/form-props/#liveomit)).
    - This resolves `must NOT have additional properties` errors caused by extra formData being preserved when selected option is changed.
3. Updated `{}` check in `preProcessHelper()` so that `[]` is not being included.
    - This resolves `must NOT have additional properties` errors caused by additional properties incorrectly added by the preprocessing logic.
4. Updated unit tests as appropriate.
