### PR TITLE
Fix 102: Fix nested constants render issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.6",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.1.2",
-        "@rjsf/core": "^5.13.0",
+        "@rjsf/core": "^5.17.1",
         "@rjsf/material-ui": "^5.13.0",
         "@rjsf/utils": "^5.13.0",
         "@rjsf/validator-ajv8": "^5.13.0",
@@ -4164,21 +4164,21 @@
       }
     },
     "node_modules/@rjsf/core": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.13.0.tgz",
-      "integrity": "sha512-rCpJGR0yPP/ip9LKcr3SmDMkbLx4QIaRA+ag0rcalSw1XLXBSzh53SpfgaB2HN++1xhUvWtIUERRHpWjQp1E7w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.17.1.tgz",
+      "integrity": "sha512-COZSuumwHskWN8Pz3RxdxvuQUP6M/qBMXAkIi+TSWLFLaF6SUugpLiceMT1jGemDCr7fOSTiPxjkToSsgpvueQ==",
       "dependencies": {
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
-        "markdown-to-jsx": "^7.3.2",
-        "nanoid": "^3.3.6",
+        "markdown-to-jsx": "^7.4.1",
+        "nanoid": "^3.3.7",
         "prop-types": "^15.8.1"
       },
       "engines": {
         "node": ">=14"
       },
       "peerDependencies": {
-        "@rjsf/utils": "^5.12.x",
+        "@rjsf/utils": "^5.16.x",
         "react": "^16.14.0 || >=17"
       }
     },
@@ -4198,9 +4198,9 @@
       }
     },
     "node_modules/@rjsf/utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.13.0.tgz",
-      "integrity": "sha512-tG2OuOJUJZ0W7VMZceD0I2SOjfMRRT1tRtG+SKbdNqhtH/gpg40aOMUj9cWgSQnYISEkNZjZq/z7NWln5RxW6A==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-q1Igz/cuM2hi+jiXFkoaXqdRTUFB+a0jfVKNmZlHmvPmfYeeJfcfyOTzO8dQ41fHNHUFb15ryxa/TblDQimwkA==",
       "dependencies": {
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
@@ -14851,9 +14851,9 @@
       }
     },
     "node_modules/markdown-to-jsx": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.3.2.tgz",
-      "integrity": "sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.3.tgz",
+      "integrity": "sha512-qwu2XftKs/SP+f6oCe0ruAFKX6jZaKxrBfDBV4CthqbVbRQwHhNM28QGDQuTldCaOn+hocaqbmGvCuXO5m3smA==",
       "engines": {
         "node": ">= 10"
       },
@@ -15207,9 +15207,9 @@
       "peer": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -25110,14 +25110,14 @@
       }
     },
     "@rjsf/core": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.13.0.tgz",
-      "integrity": "sha512-rCpJGR0yPP/ip9LKcr3SmDMkbLx4QIaRA+ag0rcalSw1XLXBSzh53SpfgaB2HN++1xhUvWtIUERRHpWjQp1E7w==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/core/-/core-5.17.1.tgz",
+      "integrity": "sha512-COZSuumwHskWN8Pz3RxdxvuQUP6M/qBMXAkIi+TSWLFLaF6SUugpLiceMT1jGemDCr7fOSTiPxjkToSsgpvueQ==",
       "requires": {
         "lodash": "^4.17.21",
         "lodash-es": "^4.17.21",
-        "markdown-to-jsx": "^7.3.2",
-        "nanoid": "^3.3.6",
+        "markdown-to-jsx": "^7.4.1",
+        "nanoid": "^3.3.7",
         "prop-types": "^15.8.1"
       }
     },
@@ -25128,9 +25128,9 @@
       "requires": {}
     },
     "@rjsf/utils": {
-      "version": "5.13.0",
-      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.13.0.tgz",
-      "integrity": "sha512-tG2OuOJUJZ0W7VMZceD0I2SOjfMRRT1tRtG+SKbdNqhtH/gpg40aOMUj9cWgSQnYISEkNZjZq/z7NWln5RxW6A==",
+      "version": "5.17.1",
+      "resolved": "https://registry.npmjs.org/@rjsf/utils/-/utils-5.17.1.tgz",
+      "integrity": "sha512-q1Igz/cuM2hi+jiXFkoaXqdRTUFB+a0jfVKNmZlHmvPmfYeeJfcfyOTzO8dQ41fHNHUFb15ryxa/TblDQimwkA==",
       "requires": {
         "json-schema-merge-allof": "^0.8.1",
         "jsonpointer": "^5.0.1",
@@ -33321,9 +33321,9 @@
       "peer": true
     },
     "markdown-to-jsx": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.3.2.tgz",
-      "integrity": "sha512-B+28F5ucp83aQm+OxNrPkS8z0tMKaeHiy0lHJs3LqCyDQFtWuenaIrkaVTgAm1pf1AU85LXltva86hlaT17i8Q==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.4.3.tgz",
+      "integrity": "sha512-qwu2XftKs/SP+f6oCe0ruAFKX6jZaKxrBfDBV4CthqbVbRQwHhNM28QGDQuTldCaOn+hocaqbmGvCuXO5m3smA==",
       "requires": {}
     },
     "mdn-data": {
@@ -33579,9 +33579,9 @@
       "peer": true
     },
     "nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA=="
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g=="
     },
     "natural-compare": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@apidevtools/json-schema-ref-parser": "^9.1.2",
-    "@rjsf/core": "^5.13.0",
+    "@rjsf/core": "^5.17.1",
     "@rjsf/material-ui": "^5.13.0",
     "@rjsf/utils": "^5.13.0",
     "@rjsf/validator-ajv8": "^5.13.0",

--- a/package.json
+++ b/package.json
@@ -51,11 +51,17 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 58,
-        "branches": 55,
-        "functions": 68,
-        "lines": 58
+        "statements": 62,
+        "branches": 61,
+        "functions": 70,
+        "lines": 62
       }
+    },
+    "transformIgnorePatterns": [
+      "/node_modules/(?!@rjsf)"
+    ],
+    "moduleNameMapper": {
+      "\\.(css|less|scss|sass)$": "identity-obj-proxy"
     }
   },
   "eslintConfig": {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -10,7 +10,6 @@ function Toolbar (props) {
      * Based on selected schema, renders a dropdown menu for version-selection.
      * Gives user the option to autofill the form with previously input data
      */
-  
   const { ParentTypeCallback, ParentVersionCallback, selectedSchemaType, selectedSchemaPath, schemaList, handleRehydrate } = props
 
   const schemaTypes = Array.from(

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -59,7 +59,7 @@ const CustomTextWidget = (props) => {
     }
   }, [props])
   return <TextWidget {...props}
-    readonly={props.schema.const !== undefined || props.readonly}
+    readonly={props.schema.const !== undefined ?? props.readonly}
     value={props.schema.const !== undefined ? toConstant(props.schema) : props.value}
   />
 }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -1,11 +1,11 @@
 import Datetime from 'react-datetime'
 import 'react-datetime/css/react-datetime.css'
 import moment from 'moment'
-import RadioWidget from '@rjsf/core/lib/components/widgets/RadioWidget'
-import CheckboxWidget from '@rjsf/core/lib/components/widgets/CheckboxWidget'
+import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
+import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
+import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
 import React from 'react'
 import PropTypes from 'prop-types'
-import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
 
 const CustomTimeWidget = (props) => {
   const onChange = (selectedDate) => {

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -1,10 +1,11 @@
 import Datetime from 'react-datetime'
 import 'react-datetime/css/react-datetime.css'
 import moment from 'moment'
-import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
-import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
+import RadioWidget from '@rjsf/core/lib/components/widgets/RadioWidget'
+import CheckboxWidget from '@rjsf/core/lib/components/widgets/CheckboxWidget'
 import React from 'react'
 import PropTypes from 'prop-types'
+import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
 
 const CustomTimeWidget = (props) => {
   const onChange = (selectedDate) => {
@@ -41,4 +42,25 @@ const CustomCheckboxWidget = (props) => {
   }
 }
 
-export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget }
+/**
+ * Custom text widget that grays out const fields (readonly) and
+ * autofills the field with the const value
+ * @param {*} props RJSF widget props
+ * @returns A custom text widget
+ */
+const CustomTextWidget = (props) => {
+  if (props.schema.const !== undefined) {
+    const newProps = {
+      ...props,
+      value: props.schema.const,
+      readonly: true
+    }
+    return <TextWidget {...newProps} />
+  }
+  return <TextWidget {...props} />
+}
+CustomTextWidget.propTypes = {
+  schema: PropTypes.object
+}
+
+export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -4,8 +4,9 @@ import moment from 'moment'
 import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
 import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
 import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
-import React, { useEffect } from 'react'
+import React, { useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
+import { toConstant } from '@rjsf/utils'
 
 const CustomTimeWidget = (props) => {
   const onChange = (selectedDate) => {
@@ -51,19 +52,15 @@ const CustomCheckboxWidget = (props) => {
  * @returns A custom text widget
  */
 const CustomTextWidget = (props) => {
-  const { schema, value, onChange, readonly } = props
-  useEffect(() => {
-    if (schema.const !== undefined && value !== schema.const) {
-      onChange(schema.const)
+  // useLayoutEffect to run effect runs before browser repaints screen (reduce flickering)
+  useLayoutEffect(() => {
+    if (props.schema.const !== undefined) {
+      props.onChange(toConstant(props.schema))
     }
-  }, [schema.const, onChange, value])
-  if (schema.const === null) {
-    return null
-  }
-  return <TextWidget{...props}
-    readonly={schema.const ? true : readonly}
-    onChange={schema.const ? () => {} : onChange}
-    value={schema.const !== undefined ? schema.const : value}
+  }, [props])
+  return <TextWidget {...props}
+    readonly={props.schema.const !== undefined || props.readonly}
+    value={props.schema.const !== undefined ? toConstant(props.schema) : props.value}
   />
 }
 CustomTextWidget.propTypes = {

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 import RadioWidget from '@rjsf/material-ui/lib/RadioWidget/RadioWidget'
 import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
 import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
-import React from 'react'
+import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 
 const CustomTimeWidget = (props) => {
@@ -43,24 +43,34 @@ const CustomCheckboxWidget = (props) => {
 }
 
 /**
- * Custom text widget that grays out const fields (readonly) and
- * autofills the field with the const value
+ * Custom text widget to enable custom behavior for constants.
+ * If string const: update formData value to const value, and return readonly text widget
+ * If null const: update formData value to null and return null
+ * Otherwise, return default text widget
  * @param {*} props RJSF widget props
  * @returns A custom text widget
  */
 const CustomTextWidget = (props) => {
-  if (props.schema.const !== undefined) {
-    const newProps = {
-      ...props,
-      value: props.schema.const,
-      readonly: true
+  const { schema, value, onChange, readonly } = props
+  useEffect(() => {
+    if (schema.const !== undefined && value !== schema.const) {
+      onChange(schema.const)
     }
-    return <TextWidget {...newProps} />
+  }, [schema.const, onChange, value])
+  if (schema.const === null) {
+    return null
   }
-  return <TextWidget {...props} />
+  return <TextWidget{...props}
+    readonly={schema.const ? true : readonly}
+    onChange={schema.const ? () => {} : onChange}
+    value={schema.const !== undefined ? schema.const : value}
+  />
 }
 CustomTextWidget.propTypes = {
-  schema: PropTypes.object
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  schema: PropTypes.object,
+  readonly: PropTypes.bool
 }
 
 export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -45,8 +45,7 @@ const CustomCheckboxWidget = (props) => {
 
 /**
  * Custom text widget to enable custom behavior for constants.
- * If string const: update formData value to const value, and return readonly text widget
- * If null const: update formData value to null and return null
+ * If const, update formData value to const value using onChange callback, render as readonly (grayed out)
  * Otherwise, return default text widget
  * @param {*} props RJSF widget props
  * @returns A custom text widget

--- a/src/custom-ui/CustomWidgets.test.js
+++ b/src/custom-ui/CustomWidgets.test.js
@@ -1,0 +1,38 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import Form from '@rjsf/core'
+import { widgets } from './CustomWidgets'
+import validator from '@rjsf/validator-ajv8'
+
+describe('CustomTextWidget', () => {
+  it('renders a TextWidget', () => {
+    const testSchema = {
+      title: 'Test String Const',
+      type: 'string'
+    }
+    render(<Form schema={testSchema}
+      validator={validator}
+      widgets={ { text: widgets.text } }
+    />)
+    expect(screen.getByLabelText('Test String Const')).toBeInTheDocument()
+  })
+
+  it('adds const value into formData and renders const input as readonly', () => {
+    const testSchema = {
+      title: 'Test String Const',
+      const: 'const example string value',
+      type: 'string'
+    }
+    render(<Form schema={testSchema}
+      validator={validator}
+      widgets={ { text: widgets.text } }
+      onSubmit={({ formData }) => {
+        expect(formData).toEqual('const example string value')
+      }
+    }
+    />)
+    expect(screen.getByDisplayValue('const example string value')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('const example string value')).toHaveAttribute('readonly')
+    fireEvent.click(screen.getByRole('button', { name: /submit/i }))
+  })
+})

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -9,6 +9,37 @@ const testSchema1 = ({
       const: 'https://github.com/AllenNeuralDynamics/data_schema/blob/main/schemas/subject.json',
       description: 'The URL reference to the schema.',
       title: 'Described by'
+    },
+    schema_version: {
+      const: '1.0.0',
+      default: '1.0.0',
+      description: 'The version of the schema.',
+      title: 'Schema Version'
+    },
+    number_const: {
+      title: 'Number with missing type',
+      const: 1,
+      default: 1
+    },
+    boolean_const: {
+      title: 'Boolean with missing type',
+      const: true,
+      default: true
+    },
+    object_const: {
+      title: 'Object with missing type',
+      const: { key: 'value' },
+      default: { key: 'value' }
+    },
+    array_const: {
+      title: 'Array with missing type',
+      const: [1, 2, 3],
+      default: [1, 2, 3]
+    },
+    null_const: {
+      title: 'Null with missing type',
+      const: null,
+      default: null
     }
   }
 })
@@ -118,10 +149,21 @@ const testSchema4 = ({
   ]
 })
 
-test('Checks preProcessSchema modifies const schema', () => {
+test('Checks preProcessSchema modifies const schema to add missing default or type', () => {
+  const expectedTypes = [
+    { key: 'describedBy', type: 'string' },
+    { key: 'schema_version', type: 'string' },
+    { key: 'number_const', type: 'number' },
+    { key: 'boolean_const', type: 'boolean' },
+    { key: 'object_const', type: 'object' },
+    { key: 'array_const', type: 'array' },
+    { key: 'null_const', type: 'null' }
+  ]
   const processedSchema1 = preProcessSchema(testSchema1)
   expect(processedSchema1.properties.describedBy.default).toBe(testSchema1.properties.describedBy.const)
-  expect(processedSchema1.properties.describedBy.readOnly).toBe(true)
+  for (const expectedType of expectedTypes) {
+    expect(processedSchema1.properties[expectedType.key].type).toBe(expectedType.type)
+  }
 })
 
 test('Checks preProcessSchema modifies dictionary additional properties', () => {
@@ -146,7 +188,6 @@ test('Checks preProcessSchema modifies discriminator property', () => {
 
 test('Checks preProcessSchema recurses through nested schema as expected', () => {
   const processedSchema3 = preProcessSchema(testSchema3)
-  expect(processedSchema3.properties.resume.properties.education.readOnly).toBe(true)
   expect(processedSchema3.properties.resume.properties.education.default).toBe(testSchema3.properties.resume.properties.education.const)
   expect(processedSchema3.definitions.PastExperience.key_points.additionalProperties).toStrictEqual({ type: 'string' })
 })

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -10,7 +10,7 @@ export const AJV_OPTIONS = {
 const preProcessHelper = (obj) => {
   /*
   Recursively iterates through schema for rendering purposes
-    Specifies type for null consts
+    Specifies type for consts if missing
     Renders dictionaries
     Displays type selection dropdown with better default text
     Enables validation for discriminator keyword

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -18,11 +18,12 @@ const preProcessHelper = (obj) => {
     if (obj[key] !== null) {
       const prop = obj[key]
 
-      // Specify type for null consts, otherwise we get undefined type warnings
-      // Note: We use a custom text widget to autofill the const value
-      // and set the field as readonly.
+      // Specify type for null consts as nullable string,
+      // otherwise we get undefined type warnings
+      // Note: We use a custom text widget to autofill the
+      // const value and set the field as readonly.
       if (prop.const === null) {
-        prop.type = 'null'
+        prop.type = ['string', 'null']
       }
 
       // if default is {}, expected value is a dictionary of strings

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -9,7 +9,7 @@ export const AJV_OPTIONS = {
 const preProcessHelper = (obj) => {
   /*
   Recursively iterates through schema for rendering purposes
-    Makes const fields non-fillable
+    Specifies type for null consts
     Renders dictionaries
     Displays type selection dropdown with better default text
     Enables validation for discriminator keyword
@@ -18,10 +18,11 @@ const preProcessHelper = (obj) => {
     if (obj[key] !== null) {
       const prop = obj[key]
 
-      // grays out const fields (readOnly) and autofills the field with the const value (default)
-      if (prop.const !== undefined) {
-        prop.readOnly = true
-        prop.default = prop.const
+      // Specify type for null consts, otherwise we get undefined type warnings
+      // Note: We use a custom text widget to autofill the const value
+      // and set the field as readonly.
+      if (prop.const === null) {
+        prop.type = 'null'
       }
 
       // if default is {}, expected value is a dictionary of strings

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,4 +1,5 @@
 import { toast } from 'react-toastify'
+import { guessType, deepEquals } from '@rjsf/utils'
 
 export const AJV_OPTIONS = {
   ajvOptionsOverrides: {
@@ -18,12 +19,12 @@ const preProcessHelper = (obj) => {
     if (obj[key] !== null) {
       const prop = obj[key]
 
-      // Specify type for null consts as nullable string,
-      // otherwise we get undefined type warnings
-      // Note: We use a custom text widget to autofill the
-      // const value and set the field as readonly.
-      if (prop.const === null) {
-        prop.type = ['string', 'null']
+      // Need to explicitly specify missing type for consts (bug in pydantic, may be fixed in next release)
+      // If default is undefined or not matching const value, set to const
+      // Note: We use a custom text widget to autofill the const value and set the field as readonly.
+      if (prop.const !== undefined) {
+        if (prop.type === undefined) { prop.type = guessType(prop.const) }
+        if (!deepEquals(prop.default, prop.const)) { prop.default = prop.const }
       }
 
       // if default is {}, expected value is a dictionary of strings


### PR DESCRIPTION
closes #102, closes #156
- added `CustomTextWidget` to enable custom behavior for constants/ pydantic Literals
    - If const, render input textbox as `readonly`, and update parent `formData` to const value using `onChange` callback
    - Non-constants text fields are unchanged
- update preprocessing schema logic to explicitly add missing `type` for consts and check that the `default` is set correctly
- update `@rjsf/core` to latest
- update unit tests as appropriate