### PR TITLE
Fix: Render null consts as nullable strings and update CustomTextWidget

### DIFF
--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -45,27 +45,35 @@ const CustomCheckboxWidget = (props) => {
 /**
  * Custom text widget to enable custom behavior for constants.
  * If const, update formData value to const value using onChange callback, render as readonly (grayed out)
+ * If null const, return null (do not display text input)
  * Otherwise, return default text widget
  * @param {*} props RJSF widget props
  * @returns A custom text widget
  */
 const CustomTextWidget = (props) => {
+  const { schema, onChange, value } = props
   // useLayoutEffect to run effect runs before browser repaints screen (reduce flickering)
   useLayoutEffect(() => {
-    if (props.schema.const !== undefined && props.value !== props.schema.const) {
-      props.onChange(props.schema.const)
+    if (schema.const !== undefined && value !== schema.const) {
+      onChange(schema.const)
     }
-  }, [props])
-  return <TextWidget {...props}
-    readonly={props.schema.const !== undefined ?? props.readonly}
-    value={props.schema.const ?? props.value}
+  }, [onChange, schema.const, value])
+
+  if (schema.const === null) {
+    return null
+  } else if (schema.const) {
+    return <TextWidget {...props}
+    readonly={true}
+    value={schema.const}
   />
+  } else {
+    return <TextWidget {...props}/>
+  }
 }
 CustomTextWidget.propTypes = {
   value: PropTypes.any,
   onChange: PropTypes.func,
-  schema: PropTypes.object,
-  readonly: PropTypes.bool
+  schema: PropTypes.object
 }
 
 export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -6,7 +6,6 @@ import CheckboxWidget from '@rjsf/material-ui/lib/CheckboxWidget/CheckboxWidget'
 import TextWidget from '@rjsf/core/lib/components/widgets/TextWidget'
 import React, { useLayoutEffect } from 'react'
 import PropTypes from 'prop-types'
-import { toConstant } from '@rjsf/utils'
 
 const CustomTimeWidget = (props) => {
   const onChange = (selectedDate) => {
@@ -53,13 +52,13 @@ const CustomCheckboxWidget = (props) => {
 const CustomTextWidget = (props) => {
   // useLayoutEffect to run effect runs before browser repaints screen (reduce flickering)
   useLayoutEffect(() => {
-    if (props.schema.const !== undefined) {
-      props.onChange(toConstant(props.schema))
+    if (props.schema.const !== undefined && props.value !== props.schema.const) {
+      props.onChange(props.schema.const)
     }
   }, [props])
   return <TextWidget {...props}
     readonly={props.schema.const !== undefined ?? props.readonly}
-    value={props.schema.const !== undefined ? toConstant(props.schema) : props.value}
+    value={props.schema.const ?? props.value}
   />
 }
 CustomTextWidget.propTypes = {

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -157,12 +157,12 @@ test('Checks preProcessSchema modifies const schema to add missing default or ty
     { key: 'boolean_const', type: 'boolean' },
     { key: 'object_const', type: 'object' },
     { key: 'array_const', type: 'array' },
-    { key: 'null_const', type: 'null' }
+    { key: 'null_const', type: ['null', 'string'] }
   ]
   const processedSchema1 = preProcessSchema(testSchema1)
   expect(processedSchema1.properties.describedBy.default).toBe(testSchema1.properties.describedBy.const)
   for (const expectedType of expectedTypes) {
-    expect(processedSchema1.properties[expectedType.key].type).toBe(expectedType.type)
+    expect(processedSchema1.properties[expectedType.key].type).toStrictEqual(expectedType.type)
   }
 })
 

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -23,7 +23,11 @@ const preProcessHelper = (obj) => {
       // If default is undefined or not matching const value, set to const
       // Note: We use a custom text widget to autofill the const value and set the field as readonly.
       if (prop.const !== undefined) {
-        if (prop.type === undefined) { prop.type = guessType(prop.const) }
+        if (prop.type === undefined) {
+          const constType = guessType(prop.const)
+          // use nullable string type for null consts to enable allOf defaults
+          prop.type = constType === 'null' ? ['null', 'string'] : constType
+        }
         if (!deepEquals(prop.default, prop.const)) { prop.default = prop.const }
       }
 


### PR DESCRIPTION
Closes #160, closes #159

- Update `CustomTextWidget` effect to update `formData` only when value does not already match const. This speeds up loading from Autofill button.
- Render null consts as nullable strings instead of strictly null fields. This is a workaround to be able to display certain subschemas that are defined by `allOf` (e.g. CameraAssembly in Rig). These subschemas require nullable strings to be able to set the default values.