### PR TITLE
processAnyOf to handle uneccessary dropdowns

### DIFF
--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -5,7 +5,7 @@ import 'bootstrap/dist/css/bootstrap.min.css'
 import { customizeValidator } from '@rjsf/validator-ajv8'
 import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
-import { AJV_OPTIONS } from '../utilities/schemaHandlers'
+import { AJV_OPTIONS, preprocessUiSchema } from '../utilities/schemaHandlers'
 
 function RenderForm (props) {
   /*
@@ -19,6 +19,9 @@ function RenderForm (props) {
   */
   const { schemaType, schema, formData } = props
   const validator = customizeValidator(AJV_OPTIONS)
+
+  const dynamicUiSchema = preprocessUiSchema(schema)
+  const mergedUiSchema = { ...uiSchema, ...dynamicUiSchema }
 
   async function saveFilePicker (event) {
     /*
@@ -46,7 +49,7 @@ function RenderForm (props) {
       schema && <Form schema={schema}
         formData={formData}
         validator={validator}
-        uiSchema={uiSchema}
+        uiSchema={mergedUiSchema}
         widgets={widgets}
         onSubmit={saveFilePicker}
         omitExtraData

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -96,4 +96,4 @@ CustomDecimalWidget.propTypes = {
   value: PropTypes.any
 }
 
-export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget, CustomDecimalWidget }
+export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget, customDecimal: CustomDecimalWidget }

--- a/src/custom-ui/CustomWidgets.js
+++ b/src/custom-ui/CustomWidgets.js
@@ -76,4 +76,24 @@ CustomTextWidget.propTypes = {
   schema: PropTypes.object
 }
 
-export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget }
+const CustomDecimalWidget = ({ value, onChange }) => {
+  const handleChange = (e) => {
+    onChange(e.target.value)
+  }
+
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={handleChange}
+      placeholder="Enter number or string..."
+    />
+  )
+}
+
+CustomDecimalWidget.propTypes = {
+  onChange: PropTypes.func.isRequired,
+  value: PropTypes.any
+}
+
+export const widgets = { checkbox: CustomCheckboxWidget, time: CustomTimeWidget, text: CustomTextWidget, CustomDecimalWidget }

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -193,9 +193,9 @@ test('Checks preProcessSchema modifies dictionary additional properties', () => 
 test('Checks preProcessSchema handles `anyOf` as needed', () => {
   const processedSchema3 = preProcessSchema(testSchema3)
   expect(processedSchema3.properties.email.type).toStrictEqual(['string', 'null'])
-  expect(processedSchema3.properties.resume.properties.gpa.type).toStrictEqual('string')
+  expect(processedSchema3.properties.resume.properties.gpa.type).toStrictEqual(['string', 'number'])
   expect(processedSchema3.properties.email.type.anyOf).toBeFalsy
-  expect(processedSchema3.properties.resume.properties.past_experiences.anyOf).toStrictEqual([ { '$ref': '#/definitions/PastExperience' }, { title: 'null', type: 'null' } ])
+  expect(processedSchema3.properties.resume.properties.past_experiences.anyOf).toStrictEqual([ { '$ref': '#/definitions/PastExperience' }, { title: 'null',type: 'null' } ])
   
 })
 

--- a/src/utilities/schemaHandler.test.js
+++ b/src/utilities/schemaHandler.test.js
@@ -1,7 +1,5 @@
 import { preProcessSchema } from './schemaHandlers'
 import SAMPLE_SCHEMA_DISCRIMINATOR from '../testing/sample-schema-discriminator.json'
-import { processDependencies } from '@rjsf/utils/lib/schema/retrieveSchema'
-import { toBeInvalid } from '@testing-library/jest-dom/matchers'
 
 const testSchema1 = ({
   type: 'object',
@@ -105,8 +103,19 @@ const testSchema3 = ({
           const: 'Farmington University',
           type: 'string'
         },
-        gpa: {
-          title: 'GPA',
+        weighted_gpa: {
+          title: 'Weighted GPA',
+          anyOf: [
+            {
+              type: 'string'
+            },
+            {
+              type: 'number'
+            }
+          ]
+        },
+        unweighted_gpa: {
+          title: 'Unweighted GPA',
           anyOf: [
             {
               type: 'string'
@@ -114,19 +123,25 @@ const testSchema3 = ({
             {
               type: 'number'
             },
+            {
+              type: 'null'
+            }
           ]
         },
         past_experiences: {
           title: 'Past Experiences',
           anyOf: [
             {
-               "$ref": '#/definitions/PastExperience'
+              $ref: '#/definitions/PastExperience'
             },
             {
-               "type": "null"
+              type: 'null'
+            },
+            {
+              type: 'string'
             }
-         ],
-      },
+          ]
+        }
       }
     }
   },
@@ -166,7 +181,6 @@ const testSchema4 = ({
   ]
 })
 
-
 test('Checks preProcessSchema modifies const schema to add missing default or type', () => {
   const expectedTypes = [
     { key: 'describedBy', type: 'string' },
@@ -193,10 +207,10 @@ test('Checks preProcessSchema modifies dictionary additional properties', () => 
 test('Checks preProcessSchema handles `anyOf` as needed', () => {
   const processedSchema3 = preProcessSchema(testSchema3)
   expect(processedSchema3.properties.email.type).toStrictEqual(['string', 'null'])
-  expect(processedSchema3.properties.resume.properties.gpa.type).toStrictEqual(['string', 'number'])
-  expect(processedSchema3.properties.email.type.anyOf).toBeFalsy
-  expect(processedSchema3.properties.resume.properties.past_experiences.anyOf).toStrictEqual([ { '$ref': '#/definitions/PastExperience' }, { title: 'null',type: 'null' } ])
-  
+  expect(processedSchema3.properties.resume.properties.weighted_gpa.type).toStrictEqual('number')
+  expect(processedSchema3.properties.email.type.anyOf).toBeFalsy()
+  expect(processedSchema3.properties.resume.properties.past_experiences.anyOf).toStrictEqual([{ $ref: '#/definitions/PastExperience' }, { title: 'null', type: 'null' }, { title: 'string', type: 'string' }])
+  expect(processedSchema3.properties.resume.properties.unweighted_gpa.type).toStrictEqual(['number', 'null'])
 })
 
 test('Checks preProcessSchema modifies discriminator property', () => {

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,43 +1,10 @@
 import { toast } from 'react-toastify'
 import { guessType, deepEquals } from '@rjsf/utils'
+import { widgets } from '../custom-ui/CustomWidgets'
 
 export const AJV_OPTIONS = {
   ajvOptionsOverrides: {
     discriminator: true
-  }
-}
-
-const processAnyOf = (prop, allowedTypes) => {
-  /*
-  Handles AnyOfs in schema.
-  Removes unneccessary dropdowns for json schema primitive types.
-  Otherwise, adds default titles to dropdown of allowed types/subschemas
-  */
-  const isAllowedType = prop.anyOf.some(option => allowedTypes.includes(option.type))
-  const isOptional = prop.anyOf.some(option => option.type === 'null')
-  const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
-  // Replace dropdown with input box
-  if (prop.anyOf.length <= 3 && isDecimal) {
-    prop.type = 'number'
-    // if optional, still allow nullable input
-    if (isOptional) {
-      prop.type = ['number', 'null']
-    }
-    delete prop.anyOf
-  } else if (prop.anyOf.length === 2 && isAllowedType && isOptional) {
-    prop.type = allowedTypes.filter(type => prop.anyOf.some(option => option.type === type))
-    prop.type = prop.type.concat('null')
-    delete prop.anyOf
-  } else {
-    // Add default titles to dropdown of allowed types/subschemas
-    Object.values(prop.anyOf).forEach(option => {
-      // if the allowed type/ subschema is not a ref nor has a title,
-      // it defaults to <parentProp.title> option 1, <prop.title> option 2, ...
-      // we can convert to display the type name instead
-      if (!option.$ref && option.type && !option.title) {
-        option.title = option.type
-      }
-    })
   }
 }
 
@@ -71,8 +38,14 @@ const preProcessHelper = (obj) => {
       }
 
       if (prop.anyOf) {
-        const allowedTypes = ['string', 'number', 'boolean', 'integer']
-        processAnyOf(prop, allowedTypes)
+        Object.values(prop.anyOf).forEach(option => {
+          // if the allowed type/ subschema is not a ref nor has a title,
+          // it defaults to <parentProp.title> option 1, <prop.title> option 2, ...
+          // we can convert to display the type name instead
+          if (!option.$ref && option.type && !option.title) {
+            option.title = option.type
+          }
+        })
       }
 
       // enable validation for discriminator keyword
@@ -112,4 +85,24 @@ export const preProcessSchema = (schema) => {
     return schema
   }
   return copiedSchema
+}
+
+export const preprocessUiSchema = (schema) => {
+  const dynamicUiSchema = {}
+
+  // Loop through properties in the schema
+  Object.keys(schema).forEach(key => {
+    if (schema[key] !== null) {
+      console.log()
+      const prop = schema[key]
+      if (prop.const !== undefined) {
+        const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
+        // Check if anyOf includes string and number types
+        if (prop.anyOf && isDecimal) {
+          dynamicUiSchema[key] = { 'ui:widget': widgets.CustomDecimalWidget }
+        }
+      }
+    }
+  })
+  return dynamicUiSchema
 }

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -10,18 +10,23 @@ export const AJV_OPTIONS = {
 const processAnyOf = (prop, allowedTypes) => {
   /*
   Handles AnyOfs in schema.
-  Removes unneccessary dropdowns for basic field types.
+  Removes unneccessary dropdowns for json schema primitive types.
   Otherwise, adds default titles to dropdown of allowed types/subschemas
   */
   const isAllowedType = prop.anyOf.some(option => allowedTypes.includes(option.type))
   const isOptional = prop.anyOf.some(option => option.type === 'null')
   const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
-
   // Replace dropdown with input box
-  if (isDecimal || isAllowedType) {
-    prop.type = allowedTypes.filter(type => prop.anyOf.some(option => option.type === type))
+  if (prop.anyOf.length <= 3 && isDecimal) {
+    prop.type = 'number'
     // if optional, still allow nullable input
-    if (isOptional) { prop.type = prop.type.concat('null') }
+    if (isOptional) {
+      prop.type = ['number', 'null']
+    }
+    delete prop.anyOf
+  } else if (prop.anyOf.length === 2 && isAllowedType && isOptional) {
+    prop.type = allowedTypes.filter(type => prop.anyOf.some(option => option.type === type))
+    prop.type = prop.type.concat('null')
     delete prop.anyOf
   } else {
     // Add default titles to dropdown of allowed types/subschemas

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -1,6 +1,6 @@
 import { toast } from 'react-toastify'
 import { guessType, deepEquals } from '@rjsf/utils'
-import { widgets } from '../custom-ui/CustomWidgets'
+// import { widgets } from '../custom-ui/CustomWidgets'
 
 export const AJV_OPTIONS = {
   ajvOptionsOverrides: {
@@ -19,7 +19,6 @@ const preProcessHelper = (obj) => {
   Object.keys(obj).forEach(key => {
     if (obj[key] !== null) {
       const prop = obj[key]
-
       // Need to explicitly specify missing type for consts (bug in pydantic, may be fixed in next release)
       // If default is undefined or not matching const value, set to const
       // Note: We use a custom text widget to autofill the const value and set the field as readonly.
@@ -89,18 +88,20 @@ export const preProcessSchema = (schema) => {
 
 export const preprocessUiSchema = (schema) => {
   const dynamicUiSchema = {}
-
   // Loop through properties in the schema
   Object.keys(schema).forEach(key => {
     if (schema[key] !== null) {
-      console.log()
       const prop = schema[key]
-      if (prop.const !== undefined) {
-        const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
-        // Check if anyOf includes string and number types
-        if (prop.anyOf && isDecimal) {
-          dynamicUiSchema[key] = { 'ui:widget': widgets.CustomDecimalWidget }
-        }
+      console.log(prop)
+      const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
+      // Check if anyOf includes string and number types
+      console.log(prop, ' IS DECIMAL')
+      if (prop.anyOf && isDecimal) {
+        dynamicUiSchema[key] = { 'ui:widget': 'decimal' }
+      }
+      // recursion
+      if (typeof (prop) === 'object') {
+        preprocessUiSchema(prop)
       }
     }
   })

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -15,7 +15,7 @@ const processAnyOf = (prop, allowedTypes) => {
   */
   const isAllowedType = prop.anyOf.some(option => allowedTypes.includes(option.type))
   const isOptional = prop.anyOf.some(option => option.type === 'null')
-  const isDecimal = prop.anyOf.some(option => option.type === 'number' || option.type === 'string')
+  const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
 
   // Replace dropdown with input box for required decimals
   if (isDecimal && !isOptional) {

--- a/src/utilities/schemaHandlers.js
+++ b/src/utilities/schemaHandlers.js
@@ -17,14 +17,11 @@ const processAnyOf = (prop, allowedTypes) => {
   const isOptional = prop.anyOf.some(option => option.type === 'null')
   const isDecimal = prop.anyOf.some(option => option.type === 'number') && prop.anyOf.some(option => option.type === 'string')
 
-  // Replace dropdown with input box for required decimals
-  if (isDecimal && !isOptional) {
-    prop.type = 'string'
-    delete prop.anyOf
-  // Replace dropdown with nullable input box for optional basic fields
-  } else if ((isDecimal || isAllowedType) && isOptional) {
+  // Replace dropdown with input box
+  if (isDecimal || isAllowedType) {
     prop.type = allowedTypes.filter(type => prop.anyOf.some(option => option.type === type))
-    prop.type = prop.type.concat('null')
+    // if optional, still allow nullable input
+    if (isOptional) { prop.type = prop.type.concat('null') }
     delete prop.anyOf
   } else {
     // Add default titles to dropdown of allowed types/subschemas


### PR DESCRIPTION
closes #148 

Handles AnyOfs so that the app no longer renders redundant dropdowns. If decimal or basic field type (string, int, bool, etc) and if optional, allows nullable input field. Otherwise, creates dropdown as needed. Also adds unit tests for a couple cases

before: 
<img width="944" alt="Screen Shot 2024-04-04 at 8 43 56 PM" src="https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/54870020/ff77cfca-07e5-4986-8658-35a473635d88">
<img width="643" alt="Screen Shot 2024-04-04 at 8 44 56 PM" src="https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/54870020/871cfaee-b355-4d69-9f51-811bc563acda">


after:
<img width="524" alt="Screen Shot 2024-04-04 at 8 42 56 PM" src="https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/54870020/9c8d3ca9-abda-4656-a1da-be8fb23fcc88">
<img width="669" alt="Screen Shot 2024-04-04 at 8 45 12 PM" src="https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/54870020/6e096f7e-c709-40bf-8e2c-3c36a145f132">


