### PR TITLE
Feat 149: Add Help button and popup UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,10 +51,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 62,
-        "branches": 61,
-        "functions": 70,
-        "lines": 62
+        "statements": 64,
+        "branches": 65,
+        "functions": 71,
+        "lines": 65
       }
     },
     "transformIgnorePatterns": [

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -17,7 +17,8 @@ const helpToast = (
     </div>
     <br />
     <h4>Getting started</h4>
-    Use this tool to create metadata files based on {getLinkAsButton(Config.AIND_DATA_SCHEMA_REPO_URL, 'aind-data-schema')}.
+    Use this tool to create metadata files based on {getLinkAsButton(Config.AIND_DATA_SCHEMA_REPO_URL, 'aind-data-schema')}
+    &nbsp;&#40;{getLinkAsButton(Config.AIND_DATA_SCHEMA_READTHEDOCS_URL, 'readthedocs')}&#41;.
     <ul>
       <li>Select a schema from the dropdown. The latest version will be loaded as a fillable form.</li>
       <li>Or, use the &apos;Autofill from file&apos; button to load an existing metadata file (must be JSON).</li>

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -3,6 +3,27 @@ import PropTypes from 'prop-types'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import { compareVersions } from 'compare-versions'
 import styles from './Toolbar.module.css'
+import { toast } from 'react-toastify'
+import Config from '../config'
+import { getLinkAsButton } from '../utilities/uiUtils'
+
+const helpToast = (
+  <div >
+    <h2 className='text-primary'>Help</h2>
+    View or submit feedback to our {getLinkAsButton(Config.REPO_URL, 'GitHub repository')}:
+    <div>
+      {getLinkAsButton(`${Config.REPO_URL}/issues`, 'Issues (bugs or feature requests)', 'View/submit bugs or feature requests', true)}
+      {getLinkAsButton(`${Config.REPO_URL}/discussions`, 'Discussions', 'View/submit discussions', true)}
+    </div>
+    <br />
+    <h4>Getting started</h4>
+    Use this tool to create metadata files based on {getLinkAsButton(Config.AIND_DATA_SCHEMA_REPO_URL, 'aind-data-schema')}.
+    <ul>
+      <li>Select a schema from the dropdown. The latest version will be loaded as a fillable form.</li>
+      <li>Or, use the &apos;Autofill from file&apos; button to load an existing metadata file (must be JSON).</li>
+      <li>The submitted metadata will be validated and saved as a JSON file to your device.</li>
+    </ul>
+  </div>)
 
 function Toolbar (props) {
   /**
@@ -32,6 +53,14 @@ function Toolbar (props) {
 
   const handleAutofill = (event) => {
     handleRehydrate()
+    event.target.blur()
+  }
+
+  const showHelpPopup = (event) => {
+    toast(helpToast, {
+      toastId: 'help-toast', // provide id to disable duplicates
+      autoClose: false
+    })
     event.target.blur()
   }
 
@@ -66,6 +95,14 @@ function Toolbar (props) {
           </option>
         ))}
       </select>
+      <button
+        title="Get help"
+        type="button"
+        className={['btn', 'btn-default', styles.btnRight].join(' ')}
+        onClick={showHelpPopup}
+      >
+        Help
+      </button>
       <button
         title="Autofill with existing data from local file"
         type="button"

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -7,5 +7,6 @@
 
 .btnRight {
     float: right;
+    margin-left: 5px;
     color: navy;
 }

--- a/src/components/Toolbar.test.js
+++ b/src/components/Toolbar.test.js
@@ -4,9 +4,11 @@ import Toolbar from './Toolbar'
 import { parseAndFilterSchemas } from '../utilities/schemaFetchers'
 import sampleSchemaLinks from '../testing/sample-schema-links.json'
 import sampleSortedVersionListInstrument from '../testing/sample-sorted-version-list-instrument.json'
+import { toast } from 'react-toastify'
 
 const nullCallback = () => { }
 const sampleSchemaList = parseAndFilterSchemas(sampleSchemaLinks)
+jest.mock('react-toastify', () => ({ toast: jest.fn() }))
 
 describe('Toolbar component', () => {
   it('renders appropriate inputs on default', () => {
@@ -21,9 +23,11 @@ describe('Toolbar component', () => {
     expect(screen.getByTitle('Select a schema')).toBeInTheDocument()
     expect(screen.getByTitle('Select a version')).toBeInTheDocument()
     expect(screen.getByTitle('Autofill with existing data from local file')).toBeInTheDocument()
+    expect(screen.getByTitle('Get help')).toBeInTheDocument()
     expect(screen.getByTitle('Select a schema')).toBeEnabled()
     expect(screen.getByTitle('Select a version')).toBeDisabled()
     expect(screen.getByTitle('Autofill with existing data from local file')).toBeEnabled()
+    expect(screen.getByTitle('Get help')).toBeEnabled()
   })
 
   it('calls ParentTypeCallback and enables version selection dropdown when a schema type is chosen', () => {
@@ -85,5 +89,37 @@ describe('Toolbar component', () => {
     />)
     fireEvent.click(screen.getByTitle('Autofill with existing data from local file'))
     expect(mockRehydrateCallback).toHaveBeenCalled()
+  })
+
+  it('displays a popup with Help info when the Help button is clicked', () => {
+    const expectedHelpDiv = expect.objectContaining({
+      type: 'div',
+      props: {
+        children: expect.arrayContaining([
+          expect.objectContaining({
+            type: 'h2',
+            props: expect.objectContaining({ children: 'Help' })
+          }),
+          expect.objectContaining({
+            type: 'h4',
+            props: expect.objectContaining({ children: 'Getting started' })
+          })
+        ])
+      }
+    })
+    const expectedToastParams = {
+      toastId: 'help-toast',
+      autoClose: false
+    }
+    render(<Toolbar
+      ParentTypeCallback={nullCallback}
+      ParentVersionCallback={nullCallback}
+      selectedSchemaType=''
+      selectedSchemaPath=''
+      schemaList={sampleSchemaList}
+      handleRehydrate={nullCallback}
+    />)
+    fireEvent.click(screen.getByTitle('Get help'))
+    expect(toast).toHaveBeenCalledWith(expectedHelpDiv, expectedToastParams)
   })
 })

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,6 @@
+const Config = {
+  REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-metadata-entry-js',
+  AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema'
+}
+
+export default Config

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,7 @@
 const Config = {
   REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-metadata-entry-js',
-  AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema'
+  AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema',
+  AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/'
 }
 
 export default Config

--- a/src/config.test.js
+++ b/src/config.test.js
@@ -1,0 +1,7 @@
+describe('config', () => {
+  it('has all required properties', () => {
+    const Config = require('./config').default
+    expect(Config.REPO_URL).toBeDefined()
+    expect(Config.AIND_DATA_SCHEMA_REPO_URL).toBeDefined()
+  })
+})

--- a/src/utilities/uiUtils.js
+++ b/src/utilities/uiUtils.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+/**
+ * Create an HTML link <a> element formatted as a button or a simple link. Link opens in a new tab.
+ * @param {string} url The link URL
+ * @param {string} text The text to display
+ * @param {string | null} tooltip The tooltip text
+ * @param {boolean | null} displayAsButton Flag to display the link as a button
+ * @returns HTML <a> element for formatted link
+ */
+export function getLinkAsButton (url, text, tooltip = '', displayAsButton = false) {
+  if (displayAsButton) {
+    return (<a href={url} target="_blank" rel='noreferrer' type="button" className="btn btn-default" title={tooltip}>{text}</a>)
+  } else {
+    return (<a href={url} target="_blank" rel='noreferrer' title={tooltip}>{text}</a>)
+  }
+}

--- a/src/utilities/uiUtils.test.js
+++ b/src/utilities/uiUtils.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import { getLinkAsButton } from './uiUtils'
+
+describe('uiUtils', () => {
+  describe('getLinkAsButton', () => {
+    const PLACEHOLDER_URL = 'https://example.com'
+    const PLACEHOLDER_TEXT = 'Example Link'
+    const PLACEHOLDER_TOOLTIP = 'This is an example link'
+    test('should return an <a> element with the correct attributes on default', () => {
+      const linkElement = getLinkAsButton(PLACEHOLDER_URL, PLACEHOLDER_TEXT)
+      render(linkElement)
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toBeInTheDocument()
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveAttribute('href', PLACEHOLDER_URL)
+      expect(screen.getByText(PLACEHOLDER_TEXT)).not.toHaveAttribute('title', PLACEHOLDER_TOOLTIP)
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveAttribute('target', '_blank')
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveAttribute('rel', 'noreferrer')
+      expect(screen.getByText(PLACEHOLDER_TEXT)).not.toHaveAttribute('type', 'button')
+      expect(screen.getByText(PLACEHOLDER_TEXT)).not.toHaveClass('btn')
+    })
+
+    test('should return an <a> element with a tooltip if specified', () => {
+      const linkElement = getLinkAsButton(PLACEHOLDER_URL, PLACEHOLDER_TEXT, PLACEHOLDER_TOOLTIP)
+      render(linkElement)
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toBeInTheDocument()
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveAttribute('title', PLACEHOLDER_TOOLTIP)
+    })
+
+    test('should return an <a> element with the correct button classes and type if displayAsButton is true', () => {
+      const linkElement = getLinkAsButton(PLACEHOLDER_URL, PLACEHOLDER_TEXT, PLACEHOLDER_TOOLTIP, true)
+      render(linkElement)
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toBeInTheDocument()
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveAttribute('type', 'button')
+      expect(screen.getByText(PLACEHOLDER_TEXT)).toHaveClass('btn btn-default')
+    })
+  })
+})


### PR DESCRIPTION
closes #149 
- Add Help button to Toolbar, which opens a popup with links to the repository to submit feedback as well as tips for getting started
- Add unit tests as appropriate

![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/b8352831-ecec-425e-947f-6ce7641967dd)
----
![image](https://github.com/AllenNeuralDynamics/aind-metadata-entry-js/assets/46795546/964afdfe-017a-4b71-8098-e31875e572b7)
