### PR TITLE
fix: inputs performance, remove `liveOmit` and add `omitExtraDataOnBlur`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,10 +49,10 @@
   "jest": {
     "coverageThreshold": {
       "global": {
-        "statements": 64,
-        "branches": 65,
-        "functions": 71,
-        "lines": 65
+        "statements": 69,
+        "branches": 67,
+        "functions": 75,
+        "lines": 69
       }
     },
     "transformIgnorePatterns": [

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -7,6 +7,7 @@ import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
 import { AJV_OPTIONS } from '../utilities/schemaHandlers'
 import { deepEquals } from '@rjsf/utils'
+import { saveToJSONFile } from '../utilities/fileUtils'
 
 function RenderForm (props) {
   /*
@@ -23,8 +24,7 @@ function RenderForm (props) {
   const validator = customizeValidator(AJV_OPTIONS)
 
   /**
-   * Custom onBlur event handler to omit extra data from formData.
-   * Based on omitExtraData logic in RJSF Form component.
+   * onBlur event handler to omit extra data from formData.
    */
   const omitExtraDataOnBlur = () => {
     // NOTE: There is a bug in RJSF `omitExtraData` logic causing validation errors.
@@ -50,25 +50,12 @@ function RenderForm (props) {
     }
   }
 
-  async function saveFilePicker (event) {
-    /*
-    File system access API to select save location
-    */
-    const data = event.formData
-    const fileData = JSON.stringify(data, undefined, 4)
-    const opts = {
-      suggestedName: `${schemaType}.json`,
-      types: [
-        {
-          description: 'JSON file',
-          accept: { 'text/plain': ['.json'] }
-        }
-      ]
-    }
-    const handle = await window.showSaveFilePicker(opts)
-    const writer = await handle.createWritable()
-    await writer.write(new Blob([fileData], { type: 'text/plain' }))
-    writer.close()
+  /**
+   * onSubmit event handler to save validated form data to a JSON file.
+   * @param {Event} event The form event
+   */
+  async function saveFileOnSubmit (event) {
+    saveToJSONFile(event.formData, schemaType)
   }
 
   if (schema) {
@@ -80,7 +67,7 @@ function RenderForm (props) {
         validator={validator}
         uiSchema={uiSchema}
         widgets={widgets}
-        onSubmit={saveFilePicker}
+        onSubmit={saveFileOnSubmit}
         onBlur={omitExtraDataOnBlur}
         omitExtraData
         noHtml5Validate >

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -50,7 +50,6 @@ function RenderForm (props) {
         widgets={widgets}
         onSubmit={saveFilePicker}
         omitExtraData
-        liveOmit
         noHtml5Validate >
       </Form>
     )

--- a/src/components/RenderForm.test.js
+++ b/src/components/RenderForm.test.js
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import RenderForm from './RenderForm'
+import { preProcessSchema } from '../utilities/schemaHandlers'
+import { saveToJSONFile } from '../utilities/fileUtils'
+import SAMPLE_SCHEMA_EXTRA_DATA from '../testing/sample-schema-discriminator-extra-data.json'
+
+const EXPECTED_PROMPT_TEXT = 'Please select a schema from the dropdown above or autofill data from an existing file.'
+const SAMPLE_SCHEMA_TYPE = 'test'
+const SAMPLE_SCHEMA = preProcessSchema(SAMPLE_SCHEMA_EXTRA_DATA)
+const SAMPLE_FORM_DATA = {
+  sub_schema: {
+    discriminator_property: 'Discriminator 1',
+    extra_data_str: 'I should only exist in Option1'
+  }
+}
+
+jest.mock('../utilities/fileUtils', () => ({ saveToJSONFile: jest.fn() }))
+
+describe('RenderForm component', () => {
+  it('renders prompt on default if no schema is provided', () => {
+    render(<RenderForm schemaType={SAMPLE_SCHEMA_TYPE} />)
+    expect(screen.getByText(EXPECTED_PROMPT_TEXT)).toBeVisible()
+    expect(screen.queryByRole('button', { name: 'Submit' })).toBeNull()
+  })
+
+  it('renders with provided schema and formData on default', () => {
+    render(<RenderForm schemaType={SAMPLE_SCHEMA_TYPE} schema={SAMPLE_SCHEMA} formData={SAMPLE_FORM_DATA} />)
+    expect(screen.queryByText(EXPECTED_PROMPT_TEXT)).toBeNull()
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeVisible()
+    expect(screen.getByText(SAMPLE_SCHEMA.title)).toBeVisible()
+    expect(screen.getByLabelText('Extra Data String')).toHaveValue(SAMPLE_FORM_DATA.sub_schema.extra_data_str)
+  })
+
+  it('saves form data on submit', () => {
+    render(<RenderForm schemaType={SAMPLE_SCHEMA_TYPE} schema={SAMPLE_SCHEMA} formData={SAMPLE_FORM_DATA} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    const formData = saveToJSONFile.mock.calls[0][0]
+    expect(formData).toEqual(SAMPLE_FORM_DATA)
+  })
+
+  it('omits extra data on blur events', () => {
+    render(<RenderForm schemaType={SAMPLE_SCHEMA_TYPE} schema={SAMPLE_SCHEMA} formData={SAMPLE_FORM_DATA} />)
+    // Select Option2, which should clear extra_data_str from initial formData
+    const option2Val = screen.getByRole('option', { name: 'Option2' }).value
+    fireEvent.change(screen.getByDisplayValue('Option1'), { target: { value: option2Val } })
+    fireEvent.blur(screen.getByDisplayValue('Option2'))
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+    const formData = saveToJSONFile.mock.calls[0][0]
+    expect(formData.sub_schema).not.toHaveProperty('extra_data_str')
+    expect(formData).toEqual({ sub_schema: { discriminator_property: 'Discriminator 2' } })
+  })
+})

--- a/src/testing/sample-schema-discriminator-extra-data.json
+++ b/src/testing/sample-schema-discriminator-extra-data.json
@@ -1,0 +1,65 @@
+{
+  "$defs": {
+    "Option1": {
+      "additionalProperties": false,
+      "description": "Description of Option1",
+      "properties": {
+        "discriminator_property": {
+          "const": "Discriminator 1",
+          "default": "Discriminator 1",
+          "title": "Discriminator 1"
+        },
+        "extra_data_str": {
+          "title": "Extra Data String",
+          "type": "string"
+        }
+      },
+      "title": "Option1",
+      "type": "object"
+    },
+    "Option2": {
+      "additionalProperties": false,
+      "description": "Description of Option2",
+      "properties": {
+        "discriminator_property": {
+          "const": "Discriminator 2",
+          "default": "Discriminator 2",
+          "title": "Discriminator 2"
+        },
+        "extra_data_num": {
+          "title": "Extra Data Number",
+          "type": "number"
+        }
+      },
+      "title": "Option2",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Sample schema with subschema with discriminator keyword.",
+  "properties": {
+    "sub_schema": {
+      "discriminator": {
+        "mapping": {
+          "Option1": "#/$defs/Option1",
+          "Option2": "#/$defs/Option2"
+        },
+        "propertyName": "discriminator_property"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/Option1"
+        },
+        {
+          "$ref": "#/$defs/Option2"
+        }
+      ],
+      "title": "Sub Schema with Discriminator Keyword"
+    }
+  },
+  "required": [
+    "sub_schema"
+  ],
+  "title": "Sample Schema with Discriminator",
+  "type": "object"
+}

--- a/src/utilities/fileUtils.js
+++ b/src/utilities/fileUtils.js
@@ -1,3 +1,5 @@
+import { toast } from 'react-toastify'
+
 /**
  * Opens file browser and reads JSON data from user-selected local file
  * @returns {Object} The file data as a JSON object
@@ -7,4 +9,32 @@ export async function readFromJSONFile () {
   const file = await fileHandle.getFile()
   const fileData = await file.text()
   return JSON.parse(fileData)
+}
+
+/**
+ * Opens file browser and saves JSON data to user-selected local file
+ * @param {Object} data The file data to save
+ * @param {string} filename The suggested filename
+ */
+export async function saveToJSONFile (data, filename) {
+  try {
+    const fileData = JSON.stringify(data, undefined, 4)
+    const opts = {
+      suggestedName: `${filename}.json`,
+      types: [
+        {
+          description: 'JSON file',
+          accept: { 'text/plain': ['.json'] }
+        }
+      ]
+    }
+    const handle = await window.showSaveFilePicker(opts)
+    const writer = await handle.createWritable()
+    await writer.write(new Blob([fileData], { type: 'text/plain' }))
+    writer.close()
+  } catch (error) {
+    if (!(error instanceof DOMException && error.name === 'AbortError')) {
+      toast.error('Error saving file. Please try again.')
+    }
+  }
 }


### PR DESCRIPTION
fixes #162 
- Removed `liveOmit` RJSF prop due to performance issues
- Added custom `omitExtraDataOnBlur` event handler as workaround for RJSF  `omitExtraData` bug
- Added unit tests for RenderForm component, minor refactor to move `saveToJSONFile` to utils.

Before: keypress event takes ~200ms for empty Rig and >2s for complex "filled" Rig
Now: keypress event takes <50ms for empty Rig and <300ms for complex "filled" Rig