### PR TITLE
feat: scrollable form with pinned toolbars

### DIFF
--- a/src/components/App.module.css
+++ b/src/components/App.module.css
@@ -1,20 +1,13 @@
 body {
-    padding: 40px;
-
     .titleSection {
         text-align: center;
-
         h1 {
             color: navy;
         }
     }
 
-    .toolbarSection {
-        margin-top: 30px;
-    }
-
     .formSection {
-        padding: 15px;
+        padding: 10px;
         border: 1px dashed grey;
 
         .error {

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -33,15 +33,6 @@ function RenderForm (props) {
     event.target.blur()
   }
 
-  /**
-   * Event handler to reset the form
-   * @param {Event} event The click event
-   */
-  const onResetForm = (event) => {
-    formRef.current.reset()
-    event.target.blur()
-  }
-
   async function saveFilePicker (event) {
     /*
     File system access API to select save location
@@ -81,7 +72,6 @@ function RenderForm (props) {
         <div className="btn-group" role="group">
           <button title="Save form data to JSON file" type="submit" className="btn btn-primary">Submit</button>
           <button title="Validate form" type="button" className="btn btn-default" onClick={onValidateForm}>Validate</button>
-          <button title="Reset form" type="button" className="btn btn-default" onClick={onResetForm}>Reset</button>
         </div>
       </Form>
     )

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createRef } from 'react'
 import PropTypes from 'prop-types'
 import Form from '@rjsf/core'
 import 'bootstrap/dist/css/bootstrap.min.css'
@@ -6,6 +6,7 @@ import { customizeValidator } from '@rjsf/validator-ajv8'
 import { widgets } from '../custom-ui/CustomWidgets'
 import { uiSchema } from '../custom-ui/CustomUISchema'
 import { AJV_OPTIONS } from '../utilities/schemaHandlers'
+import { toast } from 'react-toastify'
 
 function RenderForm (props) {
   /*
@@ -18,7 +19,28 @@ function RenderForm (props) {
     Form object
   */
   const { schemaType, schema, formData } = props
+  const formRef = createRef()
   const validator = customizeValidator(AJV_OPTIONS)
+
+  /**
+   * Event handler to validate the form
+   * @param {Event} event The click event
+   */
+  const onValidateForm = (event) => {
+    if (formRef.current.validateForm()) {
+      toast.success('Form is valid. Ready to submit!')
+    }
+    event.target.blur()
+  }
+
+  /**
+   * Event handler to reset the form
+   * @param {Event} event The click event
+   */
+  const onResetForm = (event) => {
+    formRef.current.reset()
+    event.target.blur()
+  }
 
   async function saveFilePicker (event) {
     /*
@@ -43,7 +65,9 @@ function RenderForm (props) {
 
   if (schema) {
     return (
-      schema && <Form schema={schema}
+      schema && <Form
+        ref={formRef}
+        schema={schema}
         formData={formData}
         validator={validator}
         uiSchema={uiSchema}
@@ -54,6 +78,11 @@ function RenderForm (props) {
         noHtml5Validate
         focusOnFirstError
       >
+        <div className="btn-group" role="group">
+          <button title="Save form data to JSON file" type="submit" className="btn btn-primary">Submit</button>
+          <button title="Validate form" type="button" className="btn btn-default" onClick={onValidateForm}>Validate</button>
+          <button title="Reset form" type="button" className="btn btn-default" onClick={onResetForm}>Reset</button>
+        </div>
       </Form>
     )
   } else {

--- a/src/components/RenderForm.js
+++ b/src/components/RenderForm.js
@@ -51,7 +51,9 @@ function RenderForm (props) {
         onSubmit={saveFilePicker}
         omitExtraData
         liveOmit
-        noHtml5Validate >
+        noHtml5Validate
+        focusOnFirstError
+      >
       </Form>
     )
   } else {

--- a/src/components/Toolbar.js
+++ b/src/components/Toolbar.js
@@ -67,51 +67,53 @@ function Toolbar (props) {
 
   return (
     <div>
-      <select
-        id="schema-type-select"
-        className={['btn', 'btn-default', styles.dropdown].join(' ')}
-        title='Select a schema'
-        value={selectedSchemaType}
-        onChange={handleTypeChange}
-      >
-        <option value="">Select schema</option>
-        {schemaTypes.map((schemaType) => (
-          <option key={schemaType} value={schemaType}>
-            {schemaType}
-          </option>
-        ))}
-      </select>
-      <select
-        id="schema-version-select"
-        className={['btn', 'btn-default', styles.dropdown].join(' ')}
-        title='Select a version'
-        value={selectedSchemaPath}
-        onChange={handleVersionChange}
-        disabled={!selectedSchemaType}
-      >
-        <option value="">Select version</option>
-        {schemas.map((schema) => (
-          <option key={schema.path} value={schema.path}>
-            {schema.version}
-          </option>
-        ))}
-      </select>
-      <button
-        title="Get help"
-        type="button"
-        className={['btn', 'btn-default', styles.btnRight].join(' ')}
-        onClick={showHelpPopup}
-      >
-        Help
-      </button>
-      <button
-        title="Autofill with existing data from local file"
-        type="button"
-        className={['btn', 'btn-default', styles.btnRight].join(' ')}
-        onClick={handleAutofill}
-      >
-        Autofill from file
-      </button>
+      <div className="btn-toolbar" role="toolbar">
+        <select
+          id="schema-type-select"
+          className={['btn', 'btn-default', styles.dropdown].join(' ')}
+          title='Select a schema'
+          value={selectedSchemaType}
+          onChange={handleTypeChange}
+        >
+          <option value="">Select schema</option>
+          {schemaTypes.map((schemaType) => (
+            <option key={schemaType} value={schemaType}>
+              {schemaType}
+            </option>
+          ))}
+        </select>
+        <select
+          id="schema-version-select"
+          className={['btn', 'btn-default', styles.dropdown].join(' ')}
+          title='Select a version'
+          value={selectedSchemaPath}
+          onChange={handleVersionChange}
+          disabled={!selectedSchemaType}
+        >
+          <option value="">Select version</option>
+          {schemas.map((schema) => (
+            <option key={schema.path} value={schema.path}>
+              {schema.version}
+            </option>
+          ))}
+        </select>
+        <button
+          title="Get help"
+          type="button"
+          className={['btn', 'btn-default', 'pull-right'].join(' ')}
+          onClick={showHelpPopup}
+        >
+          Help
+        </button>
+        <button
+          title="Autofill with existing data from local file"
+          type="button"
+          className={['btn', 'btn-default', 'pull-right'].join(' ')}
+          onClick={handleAutofill}
+        >
+          Autofill from file
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/components/Toolbar.module.css
+++ b/src/components/Toolbar.module.css
@@ -1,12 +1,5 @@
 .dropdown {
     font-size: medium;
     color: navy;
-    margin-right: 5px;
     text-align: left
-}
-
-.btnRight {
-    float: right;
-    margin-left: 5px;
-    color: navy;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -4,13 +4,30 @@ body {
   --toastify-toast-width: 400px;
 }
 
-Form fieldset {
-  padding-left: 8px;
-  border-left: 2px solid rgba(0, 0, 255, .25);
-  border-radius: 5px;
+Form.rjsf {
+  /* dynamically resize form and error sections */
+  .panel-danger.errors {
+    max-height: 15vh;
+    overflow-y: auto;
+    font-size: small;
+  }
+  .form-group.field.field-object fieldset#root{
+    max-height: 80vh;
+    overflow-y: auto;
+  }
+  .panel-danger.errors + .form-group.field.field-object fieldset#root{
+    max-height: 65vh;
+  }
+  
+  /* indent and border-left for nested schemas */
+  .form-group.field.field-object fieldset:not(#root){
+    padding-left: 8px;
+    border-left: 2px solid rgba(0, 0, 255, .25);
+    border-radius: 5px;
 
-  &:hover {
-      border-color: rgba(0, 0, 255, .5);
+    &:hover {
+        border-color: rgba(0, 0, 255, .5);
+    }
   }
 }
 


### PR DESCRIPTION
closes #140 
- Added css to allow scrollable form and error sections (toolbars are pinned to top and bottom)
- Added `focusOnFirstError` prop to auto-scroll to errors after validation
- Added Validate button to Form toolbar
- Simplified css in favor of bootstrap
- Updated unit tests as appropriate

NOTE: Did not add Reset button due to performance issues.