### PR TITLE
hot-fix: upper bounds for schema versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aind-metadata-entry",
-  "version": "0.1.6",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aind-metadata-entry",
-      "version": "0.1.6",
+      "version": "0.2.0",
       "dependencies": {
         "@rjsf/core": "^5.18.6",
         "@rjsf/material-ui": "^5.18.6",

--- a/src/config.js
+++ b/src/config.js
@@ -1,7 +1,17 @@
 const Config = {
   REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-metadata-entry-js',
   AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema',
-  AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/'
+  AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/',
+  SCHEMAS_UPPER_BOUNDS: {
+    acquisition: '0.6.20',
+    data_description: '0.13.11',
+    instrument: '0.10.28',
+    procedures: '0.13.14',
+    processing: '0.4.8',
+    rig: '0.5.4',
+    session: '0.3.4',
+    subject: '0.5.9'
+  }
 }
 
 export default Config

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,4 +1,5 @@
 import { validate, compareVersions } from 'compare-versions'
+import Config from '../config'
 
 /**
  * @typedef {Object} Schema
@@ -36,7 +37,13 @@ export function parseAndFilterSchemas (schemaLinks) {
   for (const link of schemaLinks) {
     const parts = link.split('/')
     if (isValidSchema(link) && !filterArray.includes(parts[1])) {
-      schemaList.push({ type: parts[1], version: parts[2], path: link })
+      const s = { type: parts[1], version: parts[2], path: link }
+      // temporary upper bound for schema versions
+      const upperBound = Config.SCHEMAS_UPPER_BOUNDS[s.type]
+      if (upperBound && compareVersions(s.version, upperBound) > 0) {
+        continue
+      }
+      schemaList.push(s)
     }
   }
   return schemaList


### PR DESCRIPTION
Add temporary upper bounds for schema versions to display only schemas prior to aind-data-schema v.1.0.