### PR TITLE
ci: github action to update package-lock and run build

### DIFF
--- a/.github/workflows/run_dev_tests.yml
+++ b/.github/workflows/run_dev_tests.yml
@@ -12,32 +12,35 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
+        ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
         node-version: "16.x"
-    - name: Update package-lock
+    - name: Check package-lock.json
+      id: check-package-lock
       run: |
         npm install
-        if [[ `git status --porcelain` ]]; then
-          echo "Changes detected in the working directory"
+        if [[ `git status --porcelain package-lock.json` ]]; then
+          echo "Changes detected in package-lock.json"
+          echo "changes_detected=true" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_HEAD_REF}" == "dev" || "${GITHUB_HEAD_REF}" == "main" ]]; then
             echo "Error: package-lock.json is outdated but cannot auto-commit to ${GITHUB_HEAD_REF}. Please review and commit the changes."
             git diff
             exit 1
-          else
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add package-lock.json
-            echo "Committing changes to package-lock.json"
-            git commit -m 'Update package-lock.json'
-            echo "Pushing changes to ${GITHUB_HEAD_REF}"
-            git push origin HEAD:${GITHUB_HEAD_REF}
           fi
         else
           echo "No changes in package-lock.json"
+          echo "changes_detected=false" >> $GITHUB_OUTPUT
         fi
+    - name: Commit and push package-lock.json
+      if: steps.check-package-lock.outputs.changes_detected == 'true'
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: "ci: update package-lock.json [skip actions]"
+        add: package-lock.json
     - name: Install dependencies (clean install)
       run: npm ci
     - name: Check build

--- a/.github/workflows/run_main_tests.yml
+++ b/.github/workflows/run_main_tests.yml
@@ -13,32 +13,35 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
       with:
+        ref: ${{ github.event.pull_request.head.ref }}
         fetch-depth: 0
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
         node-version: "16.x"
-    - name: Update package-lock
+    - name: Check package-lock.json
+      id: check-package-lock
       run: |
         npm install
-        if [[ `git status --porcelain` ]]; then
-          echo "Changes detected in the working directory"
+        if [[ `git status --porcelain package-lock.json` ]]; then
+          echo "Changes detected in package-lock.json"
+          echo "changes_detected=true" >> $GITHUB_OUTPUT
           if [[ "${GITHUB_HEAD_REF}" == "dev" || "${GITHUB_HEAD_REF}" == "main" ]]; then
             echo "Error: package-lock.json is outdated but cannot auto-commit to ${GITHUB_HEAD_REF}. Please review and commit the changes."
             git diff
             exit 1
-          else
-            git config --global user.name 'github-actions[bot]'
-            git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-            git add package-lock.json
-            echo "Committing changes to package-lock.json"
-            git commit -m 'Update package-lock.json'
-            echo "Pushing changes to ${GITHUB_HEAD_REF}"
-            git push origin HEAD:${GITHUB_HEAD_REF}
           fi
         else
           echo "No changes in package-lock.json"
+          echo "changes_detected=false" >> $GITHUB_OUTPUT
         fi
+    - name: Commit and push package-lock.json
+      if: steps.check-package-lock.outputs.changes_detected == 'true'
+      uses: EndBug/add-and-commit@v9
+      with:
+        default_author: github_actions
+        message: "ci: update package-lock.json [skip actions]"
+        add: package-lock.json
     - name: Install dependencies (clean install)
       run: npm ci
     - name: Check build

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -30,11 +30,11 @@ jobs:
         sed -i "3s/$old_version/$new_version/" package.json
     - name: Update package-lock.json
       run: npm install
-    - name: Commit and Push version bump
+    - name: Commit and push version bump
       uses: EndBug/add-and-commit@v9
       with:
         default_author: github_actions
-        message: "version bump [skip actions]"
+        message: "ci: version bump [skip actions]"
         add: |
           package.json
           package-lock.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aind-metadata-entry",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aind-metadata-entry",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "dependencies": {
         "@rjsf/core": "^5.18.6",
         "@rjsf/material-ui": "^5.18.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "aind-metadata-entry",
-  "version": "0.2.1",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "aind-metadata-entry",
-      "version": "0.2.1",
+      "version": "0.2.0",
       "dependencies": {
         "@rjsf/core": "^5.18.6",
         "@rjsf/material-ui": "^5.18.6",


### PR DESCRIPTION
closes #96, fixes #186 
- Add checks in `run_dev_tests.yml` and `run_main_tests.yml` to:
    - Update package-lock.json. Changes will be auto-committed to PR source branch unless branch is dev or main.
    - Check for build errors
- Fix bug in `tag.yml`: must also update package-lock after version bump in main