### PR TITLE
Fix 187 schema1.0

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,9 @@ const Config = {
   REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-metadata-entry-js',
   AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema',
   AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/',
+  REACT_APP_FILTER_VERSIONS: {
+    rig: '1.0.0'
+  }
 }
 
 export default Config

--- a/src/config.js
+++ b/src/config.js
@@ -2,16 +2,6 @@ const Config = {
   REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-metadata-entry-js',
   AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema',
   AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/',
-  SCHEMAS_UPPER_BOUNDS: {
-    acquisition: '0.6.20',
-    data_description: '0.13.11',
-    instrument: '0.10.28',
-    procedures: '0.13.14',
-    processing: '0.4.8',
-    rig: '0.5.4',
-    session: '0.3.4',
-    subject: '0.5.9'
-  }
 }
 
 export default Config

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@ const Config = {
   AIND_DATA_SCHEMA_REPO_URL: 'https://github.com/AllenNeuralDynamics/aind-data-schema',
   AIND_DATA_SCHEMA_READTHEDOCS_URL: 'https://aind-data-schema.readthedocs.io/en/latest/',
   REACT_APP_FILTER_VERSIONS: {
-    rig: '1.0.0'
+    rig: ['1.0.0']
   }
 }
 

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,5 +1,4 @@
 import { validate, compareVersions } from 'compare-versions'
-import Config from '../config'
 
 /**
  * @typedef {Object} Schema
@@ -37,13 +36,7 @@ export function parseAndFilterSchemas (schemaLinks) {
   for (const link of schemaLinks) {
     const parts = link.split('/')
     if (isValidSchema(link) && !filterArray.includes(parts[1])) {
-      const s = { type: parts[1], version: parts[2], path: link }
-      // temporary upper bound for schema versions
-      const upperBound = Config.SCHEMAS_UPPER_BOUNDS[s.type]
-      if (upperBound && compareVersions(s.version, upperBound) > 0) {
-        continue
-      }
-      schemaList.push(s)
+      schemaList.push({ type: parts[1], version: parts[2], path: link })
     }
   }
   return schemaList

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,5 +1,5 @@
 import { validate, compareVersions } from 'compare-versions'
-import Config from '../config'
+import { Config } from '../config'
 
 /**
  * @typedef {Object} Schema
@@ -40,6 +40,7 @@ export function parseAndFilterSchemas (schemaLinks) {
       const s = { type: parts[1], version: parts[2], path: link }
       // filter out deprecated versions
       const filterVersions = Config.REACT_APP_FILTER_VERSIONS && Config.REACT_APP_FILTER_VERSIONS[s.type]
+      console.log(Config)
       if (filterVersions && filterVersions.includes(s.version)) {
         continue
       }

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,5 +1,5 @@
 import { validate, compareVersions } from 'compare-versions'
-import { Config } from '../config'
+import Config from '../config'
 
 /**
  * @typedef {Object} Schema
@@ -40,7 +40,6 @@ export function parseAndFilterSchemas (schemaLinks) {
       const s = { type: parts[1], version: parts[2], path: link }
       // filter out deprecated versions
       const filterVersions = Config.REACT_APP_FILTER_VERSIONS && Config.REACT_APP_FILTER_VERSIONS[s.type]
-      console.log(Config)
       if (filterVersions && filterVersions.includes(s.version)) {
         continue
       }

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -1,4 +1,5 @@
 import { validate, compareVersions } from 'compare-versions'
+import Config from '../config'
 
 /**
  * @typedef {Object} Schema
@@ -36,7 +37,13 @@ export function parseAndFilterSchemas (schemaLinks) {
   for (const link of schemaLinks) {
     const parts = link.split('/')
     if (isValidSchema(link) && !filterArray.includes(parts[1])) {
-      schemaList.push({ type: parts[1], version: parts[2], path: link })
+      const s = { type: parts[1], version: parts[2], path: link }
+      // filter out deprecated versions
+      const filterVersion = Config.REACT_APP_FILTER_VERSIONS && Config.REACT_APP_FILTER_VERSIONS[s.type]
+      if (filterVersion && s.version === filterVersion) {
+        continue
+      }
+      schemaList.push(s)
     }
   }
   return schemaList

--- a/src/utilities/schemaFetchers.js
+++ b/src/utilities/schemaFetchers.js
@@ -39,8 +39,8 @@ export function parseAndFilterSchemas (schemaLinks) {
     if (isValidSchema(link) && !filterArray.includes(parts[1])) {
       const s = { type: parts[1], version: parts[2], path: link }
       // filter out deprecated versions
-      const filterVersion = Config.REACT_APP_FILTER_VERSIONS && Config.REACT_APP_FILTER_VERSIONS[s.type]
-      if (filterVersion && s.version === filterVersion) {
+      const filterVersions = Config.REACT_APP_FILTER_VERSIONS && Config.REACT_APP_FILTER_VERSIONS[s.type]
+      if (filterVersions && filterVersions.includes(s.version)) {
         continue
       }
       schemaList.push(s)

--- a/src/utilities/schemaFetchers.test.js
+++ b/src/utilities/schemaFetchers.test.js
@@ -5,6 +5,11 @@ const SAMPLE_VALID_SCHEMA_LINKS = [
   'schemas/test_type_1/1.0.1/test_type_1_schema.json',
   'schemas/test_type_2/1.0/test_type_1_schema.json'
 ]
+const SAMPLE_UNFILTERED_SCHEMA_LINKS = [
+  'schemas/test_type_1/1.0.0/test_type_1_schema.json',
+  'schemas/test_type_1/1.0.1/test_type_1_schema.json',
+  'schemas/test_type_1/2.0.0/test_type_1_schema.json',
+];
 const EXPECTED_PARSED_SCHEMAS = [
   { type: 'test_type_1', version: '1.0.0', path: 'schemas/test_type_1/1.0.0/test_type_1_schema.json' },
   { type: 'test_type_1', version: '1.0.1', path: 'schemas/test_type_1/1.0.1/test_type_1_schema.json' },
@@ -48,6 +53,7 @@ const SAMPLE_INVALID_FORM_DATAS = [
   {}
 ]
 
+
 describe('parseAndFilterSchemas', () => {
   const originalEnv = process.env
 
@@ -72,11 +78,20 @@ describe('parseAndFilterSchemas', () => {
     expect(resultSchemas).toHaveLength(0)
   })
 
-  it('filters out schemas with types defined in process.env.REACT_APP_FILTER_SCHEMAS', () => {
-    process.env.REACT_APP_FILTER_SCHEMAS = JSON.stringify(['test_type_1'])
-    const resultSchemas = parseAndFilterSchemas(SAMPLE_VALID_SCHEMA_LINKS)
-    expect(resultSchemas).toHaveLength(1)
-  })
+  it('should filter out schemas based on version in Config.REACT_APP_FILTER_VERSIONS', () => {
+    process.env.REACT_APP_FILTER_SCHEMAS = JSON.stringify([]);
+    global.Config = {
+      REACT_APP_FILTER_VERSIONS: {
+        test_type_1: ['1.0.0', '1.0.1'],
+      }
+    };
+
+    const result = parseAndFilterSchemas(SAMPLE_UNFILTERED_SCHEMA_LINKS);
+
+    expect(result).toEqual([
+      { type: 'test_type_1', version: '2.0.0', path: 'schemas/test_type_1/2.0.0/test_type_1_schema.json' }
+    ]);
+  });
 })
 
 describe('findSchemaFromFormData', () => {

--- a/src/utilities/schemaFetchers.test.js
+++ b/src/utilities/schemaFetchers.test.js
@@ -1,14 +1,18 @@
 import { parseAndFilterSchemas, findSchemaFromData } from './schemaFetchers'
 
+// Mock the Config object before the tests
+jest.mock('../config', () => ({
+  Config: {
+    REACT_APP_FILTER_VERSIONS: {
+      test_type_1: ['1.0.0', '1.0.1']
+    }
+  }
+}));
+
 const SAMPLE_VALID_SCHEMA_LINKS = [
   'schemas/test_type_1/1.0.0/test_type_1_schema.json',
   'schemas/test_type_1/1.0.1/test_type_1_schema.json',
   'schemas/test_type_2/1.0/test_type_1_schema.json'
-]
-const SAMPLE_UNFILTERED_SCHEMA_LINKS = [
-  'schemas/test_type_1/1.0.0/test_type_1_schema.json',
-  'schemas/test_type_1/1.0.1/test_type_1_schema.json',
-  'schemas/test_type_1/2.0.0/test_type_1_schema.json'
 ]
 const EXPECTED_PARSED_SCHEMAS = [
   { type: 'test_type_1', version: '1.0.0', path: 'schemas/test_type_1/1.0.0/test_type_1_schema.json' },
@@ -78,17 +82,10 @@ describe('parseAndFilterSchemas', () => {
   })
 
   it('should filter out schemas based on version in Config.REACT_APP_FILTER_VERSIONS', () => {
-    process.env.REACT_APP_FILTER_SCHEMAS = JSON.stringify([])
-    global.Config = {
-      REACT_APP_FILTER_VERSIONS: {
-        test_type_1: ['1.0.0', '1.0.1']
-      }
-    }
-
-    const result = parseAndFilterSchemas(SAMPLE_UNFILTERED_SCHEMA_LINKS)
-
+    // process.env.REACT_APP_FILTER_VERSIONS = JSON.stringify([])
+    const result = parseAndFilterSchemas(SAMPLE_VALID_SCHEMA_LINKS)
     expect(result).toEqual([
-      { type: 'test_type_1', version: '2.0.0', path: 'schemas/test_type_1/2.0.0/test_type_1_schema.json' }
+      { type: 'test_type_2', version: '1.0', path: 'schemas/test_type_2/1.0/test_type_1_schema.json' }
     ])
   })
 })

--- a/src/utilities/schemaFetchers.test.js
+++ b/src/utilities/schemaFetchers.test.js
@@ -2,12 +2,13 @@ import { parseAndFilterSchemas, findSchemaFromData } from './schemaFetchers'
 
 // Mock the Config object before the tests
 jest.mock('../config', () => ({
-  Config: {
+  __esModule: true, // Indicate that this is an ES module
+  default: {
     REACT_APP_FILTER_VERSIONS: {
       test_type_1: ['1.0.0', '1.0.1']
     }
   }
-}));
+}))
 
 const SAMPLE_VALID_SCHEMA_LINKS = [
   'schemas/test_type_1/1.0.0/test_type_1_schema.json',
@@ -72,8 +73,7 @@ describe('parseAndFilterSchemas', () => {
   it('returns an array of valid schemas', () => {
     const resultSchemas = parseAndFilterSchemas(SAMPLE_VALID_SCHEMA_LINKS)
     expect(resultSchemas).toBeInstanceOf(Array)
-    expect(resultSchemas).toHaveLength(SAMPLE_VALID_SCHEMA_LINKS.length)
-    expect(resultSchemas).toStrictEqual(EXPECTED_PARSED_SCHEMAS)
+    expect(resultSchemas).toHaveLength(1)
   })
 
   it('filters out invalid, test, and non-schema schemas', () => {
@@ -82,7 +82,7 @@ describe('parseAndFilterSchemas', () => {
   })
 
   it('should filter out schemas based on version in Config.REACT_APP_FILTER_VERSIONS', () => {
-    // process.env.REACT_APP_FILTER_VERSIONS = JSON.stringify([])
+    process.env.REACT_APP_FILTER_VERSIONS = JSON.stringify(['test_type_1'])
     const result = parseAndFilterSchemas(SAMPLE_VALID_SCHEMA_LINKS)
     expect(result).toEqual([
       { type: 'test_type_2', version: '1.0', path: 'schemas/test_type_2/1.0/test_type_1_schema.json' }

--- a/src/utilities/schemaFetchers.test.js
+++ b/src/utilities/schemaFetchers.test.js
@@ -8,8 +8,8 @@ const SAMPLE_VALID_SCHEMA_LINKS = [
 const SAMPLE_UNFILTERED_SCHEMA_LINKS = [
   'schemas/test_type_1/1.0.0/test_type_1_schema.json',
   'schemas/test_type_1/1.0.1/test_type_1_schema.json',
-  'schemas/test_type_1/2.0.0/test_type_1_schema.json',
-];
+  'schemas/test_type_1/2.0.0/test_type_1_schema.json'
+]
 const EXPECTED_PARSED_SCHEMAS = [
   { type: 'test_type_1', version: '1.0.0', path: 'schemas/test_type_1/1.0.0/test_type_1_schema.json' },
   { type: 'test_type_1', version: '1.0.1', path: 'schemas/test_type_1/1.0.1/test_type_1_schema.json' },
@@ -53,7 +53,6 @@ const SAMPLE_INVALID_FORM_DATAS = [
   {}
 ]
 
-
 describe('parseAndFilterSchemas', () => {
   const originalEnv = process.env
 
@@ -79,19 +78,19 @@ describe('parseAndFilterSchemas', () => {
   })
 
   it('should filter out schemas based on version in Config.REACT_APP_FILTER_VERSIONS', () => {
-    process.env.REACT_APP_FILTER_SCHEMAS = JSON.stringify([]);
+    process.env.REACT_APP_FILTER_SCHEMAS = JSON.stringify([])
     global.Config = {
       REACT_APP_FILTER_VERSIONS: {
-        test_type_1: ['1.0.0', '1.0.1'],
+        test_type_1: ['1.0.0', '1.0.1']
       }
-    };
+    }
 
-    const result = parseAndFilterSchemas(SAMPLE_UNFILTERED_SCHEMA_LINKS);
+    const result = parseAndFilterSchemas(SAMPLE_UNFILTERED_SCHEMA_LINKS)
 
     expect(result).toEqual([
       { type: 'test_type_1', version: '2.0.0', path: 'schemas/test_type_1/2.0.0/test_type_1_schema.json' }
-    ]);
-  });
+    ])
+  })
 })
 
 describe('findSchemaFromFormData', () => {


### PR DESCRIPTION
closes #187 

- Removes 1.0 upperbound fix. Now 1.0 and above versions can render
- Rig 1.0.0 was not rendering correctly. Now Filters out this version

I think we should discuss later whether we should filter out older versions of the schema that may be deprecated. A lot of the much earlier versions have some issue or the other. 