### PR TITLE
feat: loading indicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ The source code for the React app is located in the `/src` directory.
 The project is organized as follows:
 - components - global shared/reusable components, such as inputs (buttons, dropdowns) and layout (wrappers, navigation)
 - contexts - global context providers for state management
-- utils - utilities, helpers, constants/ config
+- custom-ui - custom uiSchema and widgets for RJSF form
+- utils - helpers, constants/ config
 - views - main UI components or "pages", such as the the `MetadataEntryPage`
 - tests - unit tests and static json resources for test inputs
 
@@ -29,10 +30,11 @@ The entrypoint for the application is `index.js`, and `App.js` sets up the intia
 .
 └── /src
     ├── /components
-    ├── /services
-    ├── /store
+    ├── /contexts
+    ├── /custom-ui
     ├── /utils
-    ├── /views    
+    ├── /views
+    ├── /tests
     ├── index.js
     └── App.js
 ```

--- a/src/contexts/schema.context.js
+++ b/src/contexts/schema.context.js
@@ -21,6 +21,7 @@ export const SchemaContext = createContext()
  *    Gives user the option to autofill the form with previously input data
  */
 export const SchemaContextProvider = ({ children }) => {
+  const [loading, setLoading] = useState(false) // loading state for async operations
   const [formData, setFormData] = useState(null) // formData for rjsf form
   const [schema, setSchema] = useState(null) // JSON schema contents for rjsf form
 
@@ -110,6 +111,7 @@ export const SchemaContextProvider = ({ children }) => {
 
   return (
     <SchemaContext.Provider value={{
+      loading,
       formData,
       schema,
       selectedSchemaType,

--- a/src/contexts/schema.context.js
+++ b/src/contexts/schema.context.js
@@ -87,6 +87,7 @@ export const SchemaContextProvider = ({ children }) => {
    * @param {string} schemaPath - The path to the new schema to use
    */
   const fetchAndSetSchema = async (schemaPath) => {
+    setLoading(true)
     try {
       setFormData(null)
       const schema = await fetchSchemaContentAsync(schemaPath)
@@ -107,6 +108,7 @@ export const SchemaContextProvider = ({ children }) => {
       console.error(error)
       toast.error(`Unable to render ${schemaPath}`)
     }
+    setLoading(false)
   }
 
   return (

--- a/src/tests/contexts/schema.context.test.js
+++ b/src/tests/contexts/schema.context.test.js
@@ -29,6 +29,7 @@ describe('SchemaContextProvider', () => {
 
   it('provides correct default states', () => {
     const expectedDefaultStates = {
+      loading: false,
       formData: null,
       schema: null,
       selectedSchemaType: '',

--- a/src/tests/contexts/schema.context.test.js
+++ b/src/tests/contexts/schema.context.test.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { toast } from 'react-toastify'
 import * as fileHelpers from '../../utils/helpers/file.helpers'
 import * as schemaFetchers from '../../utils/helpers/schema.helpers'
@@ -59,11 +59,12 @@ describe('SchemaContextProvider', () => {
   })
 
   describe('fetchAndSetSchema and updateSelectedSchemaVersion', () => {
-    it('fetches and sets schema based on schema path', async () => {
-      const mockChildComponent = ({ selectedSchemaPath, updateSelectedSchemaVersion }) => (
+    it('fetches and sets schema based on schema path and sets loading states', async () => {
+      const mockChildComponent = ({ loading, selectedSchemaPath, updateSelectedSchemaVersion }) => (
         <div>
-          <button data-testid='test-update-schema-version-btn' onClick={() => updateSelectedSchemaVersion('test_type_1.py')}>Update Schema Version</button >
-          <span>{selectedSchemaPath ? `Schema path: ${selectedSchemaPath}` : 'No schema path'}</span>
+          <button data-testid='test-update-schema-version-btn' onClick={() => updateSelectedSchemaVersion('test_type_1.py')}>Update Schema Version</button>
+          <span data-testid="loading-state">{String(loading)}</span>
+          <span data-testid="selected-schema-path">{selectedSchemaPath ? `Schema path: ${selectedSchemaPath}` : 'No schema path'}</span>
         </div>
       )
       render(
@@ -71,9 +72,15 @@ describe('SchemaContextProvider', () => {
           <SchemaContext.Consumer>{mockChildComponent}</SchemaContext.Consumer>
         </SchemaContextProvider>
       )
+      expect(screen.getByTestId('loading-state').textContent).toBe('false')
+      expect(screen.getByTestId('selected-schema-path').textContent).toBe('No schema path')
+
       await fireEvent.click(await screen.findByTestId('test-update-schema-version-btn'))
+
+      await waitFor(() => { expect(screen.getByTestId('loading-state').textContent).toBe('true') })
+      await waitFor(() => { expect(screen.getByTestId('loading-state').textContent).toBe('false') })
       expect(global.fetch).toHaveBeenCalledTimes(1)
-      expect(await screen.findByText('Schema path: test_type_1.py')).toBeVisible()
+      expect(screen.getByTestId('selected-schema-path').textContent).toBe('Schema path: test_type_1.py')
     })
 
     it('handles errors when fetching schema', async () => {

--- a/src/tests/views/RenderForm.test.js
+++ b/src/tests/views/RenderForm.test.js
@@ -38,18 +38,28 @@ const renderWithContext = (context) => {
 }
 
 describe('RenderForm component', () => {
-  it('renders prompt on default if no schema is provided', () => {
-    renderWithContext({ selectedSchemaType: SCHEMA_TYPE })
+  it('renders prompt on default if no schema is provided and loading state is false', () => {
+    renderWithContext({ loading: false, selectedSchemaType: SCHEMA_TYPE })
     expect(screen.getByText(EXPECTED_PROMPT_TEXT)).toBeVisible()
     expect(screen.queryByRole('button', { name: 'Submit' })).toBeNull()
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.queryByText('Loading...')).toBeNull()
   })
 
-  it('renders with provided schema and formData on default', () => {
-    renderWithContext({ selectedSchemaType: SCHEMA_TYPE, schema: SCHEMA, formData: FORM_DATA })
+  it('renders with provided schema and formData on default and loading state is false', () => {
+    renderWithContext({ loading: false, selectedSchemaType: SCHEMA_TYPE, schema: SCHEMA, formData: FORM_DATA })
     expect(screen.queryByText(EXPECTED_PROMPT_TEXT)).toBeNull()
     expect(screen.getByRole('button', { name: 'Submit' })).toBeVisible()
     expect(screen.getByText(SCHEMA.title)).toBeVisible()
     expect(screen.getByLabelText('Extra Data String')).toHaveValue(FORM_DATA.sub_schema.extra_data_str)
+    expect(screen.queryByRole('status')).toBeNull()
+    expect(screen.queryByText('Loading...')).toBeNull()
+  })
+
+  it('renders loading indicator when loading state is true', () => {
+    renderWithContext({ loading: true })
+    expect(screen.getByRole('status')).toBeVisible()
+    expect(screen.getByText('Loading...')).toBeVisible()
   })
 
   it('saves form data on submit', () => {

--- a/src/views/RenderForm.js
+++ b/src/views/RenderForm.js
@@ -14,7 +14,7 @@ import { SchemaContext } from '../contexts/schema.context'
  * Uses SchemaContext to get states (e.g. schema, formData) to render the form. for the form)
  */
 function RenderForm () {
-  const { selectedSchemaType, schema, formData } = useContext(SchemaContext)
+  const { loading, selectedSchemaType, schema, formData } = useContext(SchemaContext)
   const formRef = createRef()
   const validator = customizeValidator(Config.AJV_OPTIONS)
 
@@ -45,6 +45,15 @@ function RenderForm () {
       if (error.property) { error.stack = `${error.property}: ${error.stack}` }
       return error
     })
+  }
+
+  if (loading) {
+    return (
+      <div className="d-flex align-items-center">
+        <div className="spinner-border text-secondary mr-2" role="status"></div>
+        <div>Loading...</div>
+      </div>
+    )
   }
 
   if (schema) {

--- a/src/views/RenderForm.js
+++ b/src/views/RenderForm.js
@@ -54,8 +54,8 @@ function RenderForm () {
         schema={schema}
         formData={formData}
         validator={validator}
-        uiSchema={widgets}
-        widgets={uiSchema}
+        uiSchema={uiSchema}
+        widgets={widgets}
         onSubmit={saveFileOnSubmit}
         transformErrors={transformErrors}
         omitExtraData


### PR DESCRIPTION
closes #146 

This PR adds a loading spinner when schemas are being loaded:
- Sets new `loading` state in context manager whenever schemas are loaded
- Updates form component to display spinner based on `loading` state
- Also fixes README and typo from previous refactor


![image](https://github.com/user-attachments/assets/3d96ebed-e921-4599-a4dc-75bfff005f8e)
